### PR TITLE
[fleet/test] #1 Tests for single-agent workflow with PR watch loop

### DIFF
--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -12,6 +12,8 @@ type Config struct {
 	Agent    AgentConfig    `toml:"agent"`
 	Test     TestConfig     `toml:"test"`
 	Validate ValidateConfig `toml:"validate"`
+	Watch    WatchConfig    `toml:"watch"`
+	CI       CIConfig       `toml:"ci"`
 }
 
 type AgentConfig struct {
@@ -27,12 +29,34 @@ type ValidateConfig struct {
 	MaxCycles    int `toml:"max_cycles"`
 }
 
+type WatchConfig struct {
+	PollInterval string `toml:"poll_interval"`
+	Timeout      string `toml:"timeout"`
+	IdleTimeout  string `toml:"idle_timeout"`
+	MaxFixRounds int    `toml:"max_fix_rounds"`
+}
+
+type CIConfig struct {
+	Enabled        bool     `toml:"enabled"`
+	RequiredChecks []string `toml:"required_checks"`
+}
+
 func defaults() Config {
 	return Config{
 		Agent: AgentConfig{Backend: "claude-code"},
 		Validate: ValidateConfig{
 			MaxFixRounds: 3,
 			MaxCycles:    2,
+		},
+		Watch: WatchConfig{
+			PollInterval: "30s",
+			Timeout:      "2h",
+			IdleTimeout:  "30m",
+			MaxFixRounds: 5,
+		},
+		CI: CIConfig{
+			Enabled:        true,
+			RequiredChecks: []string{},
 		},
 	}
 }

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -1,0 +1,283 @@
+package config
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestDefaults(t *testing.T) {
+	dir := t.TempDir()
+	cfg, err := Load(dir)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// Existing defaults
+	if cfg.Agent.Backend != "claude-code" {
+		t.Errorf("agent.backend = %q, want \"claude-code\"", cfg.Agent.Backend)
+	}
+	if cfg.Validate.MaxFixRounds != 3 {
+		t.Errorf("validate.max_fix_rounds = %d, want 3", cfg.Validate.MaxFixRounds)
+	}
+	if cfg.Validate.MaxCycles != 2 {
+		t.Errorf("validate.max_cycles = %d, want 2", cfg.Validate.MaxCycles)
+	}
+
+	// Watch defaults
+	if cfg.Watch.PollInterval != "30s" {
+		t.Errorf("watch.poll_interval = %q, want \"30s\"", cfg.Watch.PollInterval)
+	}
+	if cfg.Watch.Timeout != "2h" {
+		t.Errorf("watch.timeout = %q, want \"2h\"", cfg.Watch.Timeout)
+	}
+	if cfg.Watch.IdleTimeout != "30m" {
+		t.Errorf("watch.idle_timeout = %q, want \"30m\"", cfg.Watch.IdleTimeout)
+	}
+	if cfg.Watch.MaxFixRounds != 5 {
+		t.Errorf("watch.max_fix_rounds = %d, want 5", cfg.Watch.MaxFixRounds)
+	}
+
+	// CI defaults
+	if !cfg.CI.Enabled {
+		t.Error("ci.enabled should default to true")
+	}
+	if cfg.CI.RequiredChecks == nil {
+		t.Error("ci.required_checks should default to empty slice, not nil")
+	}
+	if len(cfg.CI.RequiredChecks) != 0 {
+		t.Errorf("ci.required_checks should be empty, got %v", cfg.CI.RequiredChecks)
+	}
+}
+
+func TestLoadMissingFile(t *testing.T) {
+	dir := t.TempDir()
+	cfg, err := Load(dir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	// Should return defaults when no config file exists
+	if cfg.Agent.Backend != "claude-code" {
+		t.Errorf("expected default backend, got %q", cfg.Agent.Backend)
+	}
+}
+
+func TestLoadWatchConfig(t *testing.T) {
+	dir := t.TempDir()
+	cfgDir := filepath.Join(dir, ".fleet")
+	if err := os.MkdirAll(cfgDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+
+	data := `[agent]
+backend = "claude-code"
+
+[watch]
+poll_interval = "60s"
+timeout = "4h"
+idle_timeout = "1h"
+max_fix_rounds = 10
+`
+	if err := os.WriteFile(filepath.Join(cfgDir, "config.toml"), []byte(data), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	cfg, err := Load(dir)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if cfg.Watch.PollInterval != "60s" {
+		t.Errorf("poll_interval = %q, want \"60s\"", cfg.Watch.PollInterval)
+	}
+	if cfg.Watch.Timeout != "4h" {
+		t.Errorf("timeout = %q, want \"4h\"", cfg.Watch.Timeout)
+	}
+	if cfg.Watch.IdleTimeout != "1h" {
+		t.Errorf("idle_timeout = %q, want \"1h\"", cfg.Watch.IdleTimeout)
+	}
+	if cfg.Watch.MaxFixRounds != 10 {
+		t.Errorf("max_fix_rounds = %d, want 10", cfg.Watch.MaxFixRounds)
+	}
+}
+
+func TestLoadCIConfig(t *testing.T) {
+	dir := t.TempDir()
+	cfgDir := filepath.Join(dir, ".fleet")
+	if err := os.MkdirAll(cfgDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+
+	data := `[agent]
+backend = "claude-code"
+
+[ci]
+enabled = false
+required_checks = ["build", "test", "lint"]
+`
+	if err := os.WriteFile(filepath.Join(cfgDir, "config.toml"), []byte(data), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	cfg, err := Load(dir)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if cfg.CI.Enabled {
+		t.Error("ci.enabled should be false")
+	}
+	if len(cfg.CI.RequiredChecks) != 3 {
+		t.Fatalf("ci.required_checks len = %d, want 3", len(cfg.CI.RequiredChecks))
+	}
+	expected := []string{"build", "test", "lint"}
+	for i, want := range expected {
+		if cfg.CI.RequiredChecks[i] != want {
+			t.Errorf("ci.required_checks[%d] = %q, want %q", i, cfg.CI.RequiredChecks[i], want)
+		}
+	}
+}
+
+func TestLoadPartialWatchConfig(t *testing.T) {
+	dir := t.TempDir()
+	cfgDir := filepath.Join(dir, ".fleet")
+	if err := os.MkdirAll(cfgDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+
+	// Only specify timeout; other watch fields should use defaults
+	data := `[agent]
+backend = "claude-code"
+
+[watch]
+timeout = "6h"
+`
+	if err := os.WriteFile(filepath.Join(cfgDir, "config.toml"), []byte(data), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	cfg, err := Load(dir)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if cfg.Watch.Timeout != "6h" {
+		t.Errorf("timeout = %q, want \"6h\"", cfg.Watch.Timeout)
+	}
+	// Defaults for unspecified fields
+	if cfg.Watch.PollInterval != "30s" {
+		t.Errorf("poll_interval = %q, want default \"30s\"", cfg.Watch.PollInterval)
+	}
+	if cfg.Watch.IdleTimeout != "30m" {
+		t.Errorf("idle_timeout = %q, want default \"30m\"", cfg.Watch.IdleTimeout)
+	}
+	if cfg.Watch.MaxFixRounds != 5 {
+		t.Errorf("max_fix_rounds = %d, want default 5", cfg.Watch.MaxFixRounds)
+	}
+}
+
+func TestLoadTestCommand(t *testing.T) {
+	dir := t.TempDir()
+	cfgDir := filepath.Join(dir, ".fleet")
+	if err := os.MkdirAll(cfgDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+
+	data := `[agent]
+backend = "claude-code"
+
+[test]
+command = "make test"
+`
+	if err := os.WriteFile(filepath.Join(cfgDir, "config.toml"), []byte(data), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	cfg, err := Load(dir)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if cfg.Test.Command != "make test" {
+		t.Errorf("test.command = %q, want \"make test\"", cfg.Test.Command)
+	}
+}
+
+func TestInvalidBackend(t *testing.T) {
+	dir := t.TempDir()
+	cfgDir := filepath.Join(dir, ".fleet")
+	if err := os.MkdirAll(cfgDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+
+	data := `[agent]
+backend = "gpt-4"
+`
+	if err := os.WriteFile(filepath.Join(cfgDir, "config.toml"), []byte(data), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	_, err := Load(dir)
+	if err == nil {
+		t.Fatal("expected error for unsupported backend")
+	}
+}
+
+func TestLoadFullConfig(t *testing.T) {
+	dir := t.TempDir()
+	cfgDir := filepath.Join(dir, ".fleet")
+	if err := os.MkdirAll(cfgDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+
+	data := `[agent]
+backend = "cursor"
+
+[test]
+command = "go test ./..."
+
+[watch]
+poll_interval = "45s"
+timeout = "3h"
+idle_timeout = "20m"
+max_fix_rounds = 8
+
+[ci]
+enabled = true
+required_checks = ["ci/build"]
+
+[validate]
+max_fix_rounds = 5
+max_cycles = 3
+`
+	if err := os.WriteFile(filepath.Join(cfgDir, "config.toml"), []byte(data), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	cfg, err := Load(dir)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if cfg.Agent.Backend != "cursor" {
+		t.Errorf("backend = %q", cfg.Agent.Backend)
+	}
+	if cfg.Test.Command != "go test ./..." {
+		t.Errorf("test.command = %q", cfg.Test.Command)
+	}
+	if cfg.Watch.PollInterval != "45s" {
+		t.Errorf("watch.poll_interval = %q", cfg.Watch.PollInterval)
+	}
+	if cfg.Watch.MaxFixRounds != 8 {
+		t.Errorf("watch.max_fix_rounds = %d", cfg.Watch.MaxFixRounds)
+	}
+	if !cfg.CI.Enabled {
+		t.Error("ci.enabled should be true")
+	}
+	if len(cfg.CI.RequiredChecks) != 1 || cfg.CI.RequiredChecks[0] != "ci/build" {
+		t.Errorf("ci.required_checks = %v", cfg.CI.RequiredChecks)
+	}
+	if cfg.Validate.MaxFixRounds != 5 {
+		t.Errorf("validate.max_fix_rounds = %d", cfg.Validate.MaxFixRounds)
+	}
+}

--- a/internal/state/state.go
+++ b/internal/state/state.go
@@ -22,7 +22,13 @@ const (
 	PhasePRs      Phase = "prs"       // PRs created
 	PhaseReview   Phase = "review"    // review completed
 	PhaseValidate Phase = "validate"  // cross-validation passed
-	PhaseDone     Phase = "done"      // delivery PR created, issue closed
+
+	// Single-agent workflow phases (replaces Dispatch→Push→PRs→Review→Validate)
+	PhaseImplement Phase = "implement" // single agent completed implementation + tests
+	PhasePR        Phase = "pr"        // branch pushed + PR created
+	PhaseWatch     Phase = "watch"     // watching PR for feedback
+
+	PhaseDone Phase = "done" // delivery PR created, issue closed
 )
 
 var phaseOrder = map[Phase]int{
@@ -33,7 +39,11 @@ var phaseOrder = map[Phase]int{
 	PhasePRs:      4,
 	PhaseReview:   5,
 	PhaseValidate: 6,
-	PhaseDone:     7,
+	// Single-agent workflow ordering
+	PhaseImplement: 10,
+	PhasePR:        11,
+	PhaseWatch:     12,
+	PhaseDone:      99,
 }
 
 func (p Phase) String() string {
@@ -79,6 +89,16 @@ type RunState struct {
 	ValRound   int  `json:"val_round"`
 
 	DeliverPR *PRInfo `json:"deliver_pr,omitempty"`
+
+	// Single-agent workflow fields
+	Branch string  `json:"branch,omitempty"` // single branch (e.g. "fleet/42")
+	PR     *PRInfo `json:"pr,omitempty"`     // single PR
+
+	// Watch loop state
+	ProcessedEvents []string  `json:"processed_events,omitempty"`
+	LastEventAt     time.Time `json:"last_event_at,omitempty"`
+	FixCount        int       `json:"fix_count,omitempty"`
+	WatchStartedAt  time.Time `json:"watch_started_at,omitempty"`
 
 	UpdatedAt time.Time `json:"updated_at"`
 

--- a/internal/state/state_watch_test.go
+++ b/internal/state/state_watch_test.go
@@ -1,0 +1,337 @@
+package state
+
+import (
+	"encoding/json"
+	"os"
+	"testing"
+	"time"
+)
+
+// ---------------------------------------------------------------------------
+// New phases
+// ---------------------------------------------------------------------------
+
+func TestNewPhaseConstants(t *testing.T) {
+	tests := []struct {
+		phase Phase
+		str   string
+	}{
+		{PhaseImplement, "implement"},
+		{PhasePR, "pr"},
+		{PhaseWatch, "watch"},
+	}
+	for _, tt := range tests {
+		if string(tt.phase) != tt.str {
+			t.Errorf("Phase(%q) string = %q, want %q", tt.phase, string(tt.phase), tt.str)
+		}
+	}
+}
+
+func TestNewPhaseOrdering(t *testing.T) {
+	// The new single-agent pipeline: New → Intake → Implement → PR → Watch → Done
+	phases := []Phase{PhaseNew, PhaseIntake, PhaseImplement, PhasePR, PhaseWatch, PhaseDone}
+
+	for i := 1; i < len(phases); i++ {
+		if !phases[i].AtLeast(phases[i-1]) {
+			t.Errorf("%s should be AtLeast %s", phases[i], phases[i-1])
+		}
+		if phases[i-1].AtLeast(phases[i]) {
+			t.Errorf("%s should not be AtLeast %s", phases[i-1], phases[i])
+		}
+	}
+	for _, p := range phases {
+		if !p.AtLeast(p) {
+			t.Errorf("%s should be AtLeast itself", p)
+		}
+	}
+}
+
+func TestImplementBeforePR(t *testing.T) {
+	if !PhasePR.AtLeast(PhaseImplement) {
+		t.Error("PR phase should come after Implement")
+	}
+	if PhaseImplement.AtLeast(PhasePR) {
+		t.Error("Implement should come before PR")
+	}
+}
+
+func TestWatchAfterPR(t *testing.T) {
+	if !PhaseWatch.AtLeast(PhasePR) {
+		t.Error("Watch phase should come after PR")
+	}
+	if PhasePR.AtLeast(PhaseWatch) {
+		t.Error("PR should come before Watch")
+	}
+}
+
+func TestDoneAfterWatch(t *testing.T) {
+	if !PhaseDone.AtLeast(PhaseWatch) {
+		t.Error("Done should come after Watch")
+	}
+	if PhaseWatch.AtLeast(PhaseDone) {
+		t.Error("Watch should come before Done")
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Single branch field (no more dual worktrees)
+// ---------------------------------------------------------------------------
+
+func TestSingleBranchField(t *testing.T) {
+	dir := t.TempDir()
+	s := New(dir, "owner", "repo", 42)
+
+	s.Branch = "fleet/42"
+	if err := s.Save(); err != nil {
+		t.Fatal(err)
+	}
+
+	loaded, err := Load(dir, 42)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if loaded.Branch != "fleet/42" {
+		t.Errorf("Branch = %q, want \"fleet/42\"", loaded.Branch)
+	}
+}
+
+func TestSinglePRField(t *testing.T) {
+	dir := t.TempDir()
+	s := New(dir, "owner", "repo", 42)
+
+	s.PR = &PRInfo{Number: 100, URL: "https://github.com/owner/repo/pull/100"}
+	if err := s.Save(); err != nil {
+		t.Fatal(err)
+	}
+
+	loaded, err := Load(dir, 42)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if loaded.PR == nil {
+		t.Fatal("PR should not be nil")
+	}
+	if loaded.PR.Number != 100 {
+		t.Errorf("PR.Number = %d, want 100", loaded.PR.Number)
+	}
+	if loaded.PR.URL != "https://github.com/owner/repo/pull/100" {
+		t.Errorf("PR.URL = %q", loaded.PR.URL)
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Watch state fields
+// ---------------------------------------------------------------------------
+
+func TestWatchStateFields(t *testing.T) {
+	dir := t.TempDir()
+	s := New(dir, "owner", "repo", 42)
+
+	now := time.Now().Truncate(time.Second)
+	s.Branch = "fleet/42"
+	s.PR = &PRInfo{Number: 100, URL: "https://github.com/owner/repo/pull/100"}
+	s.ProcessedEvents = []string{"comment-123", "review-456"}
+	s.LastEventAt = now
+	s.FixCount = 2
+	s.WatchStartedAt = now.Add(-1 * time.Hour)
+
+	if err := s.Advance(PhaseWatch); err != nil {
+		t.Fatal(err)
+	}
+
+	loaded, err := Load(dir, 42)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if loaded.Phase != PhaseWatch {
+		t.Errorf("Phase = %q, want \"watch\"", loaded.Phase)
+	}
+	if loaded.Branch != "fleet/42" {
+		t.Errorf("Branch = %q", loaded.Branch)
+	}
+	if len(loaded.ProcessedEvents) != 2 {
+		t.Fatalf("ProcessedEvents len = %d, want 2", len(loaded.ProcessedEvents))
+	}
+	if loaded.ProcessedEvents[0] != "comment-123" {
+		t.Errorf("ProcessedEvents[0] = %q", loaded.ProcessedEvents[0])
+	}
+	if loaded.ProcessedEvents[1] != "review-456" {
+		t.Errorf("ProcessedEvents[1] = %q", loaded.ProcessedEvents[1])
+	}
+	if loaded.FixCount != 2 {
+		t.Errorf("FixCount = %d, want 2", loaded.FixCount)
+	}
+	if !loaded.LastEventAt.Equal(now) {
+		t.Errorf("LastEventAt = %v, want %v", loaded.LastEventAt, now)
+	}
+	if !loaded.WatchStartedAt.Equal(now.Add(-1 * time.Hour)) {
+		t.Errorf("WatchStartedAt = %v", loaded.WatchStartedAt)
+	}
+}
+
+func TestWatchStateResumability(t *testing.T) {
+	dir := t.TempDir()
+
+	// Simulate initial run: Intake → Implement → PR → Watch (in progress)
+	s := New(dir, "owner", "repo", 10)
+	s.Branch = "fleet/10"
+	s.PR = &PRInfo{Number: 50, URL: "https://github.com/owner/repo/pull/50"}
+	s.ProcessedEvents = []string{"comment-1", "comment-2"}
+	s.FixCount = 1
+	s.WatchStartedAt = time.Now().Add(-30 * time.Minute).Truncate(time.Second)
+	s.LastEventAt = time.Now().Add(-5 * time.Minute).Truncate(time.Second)
+	if err := s.Advance(PhaseWatch); err != nil {
+		t.Fatal(err)
+	}
+
+	// Simulate resume: Load state and verify all watch fields are preserved
+	loaded, err := Load(dir, 10)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if loaded == nil {
+		t.Fatal("state should exist")
+	}
+	if loaded.Phase != PhaseWatch {
+		t.Errorf("resumed phase = %q, want \"watch\"", loaded.Phase)
+	}
+	if loaded.Branch != "fleet/10" {
+		t.Errorf("resumed branch = %q", loaded.Branch)
+	}
+	if loaded.PR == nil || loaded.PR.Number != 50 {
+		t.Error("resumed PR should be preserved")
+	}
+	if len(loaded.ProcessedEvents) != 2 {
+		t.Errorf("resumed ProcessedEvents len = %d, want 2", len(loaded.ProcessedEvents))
+	}
+	if loaded.FixCount != 1 {
+		t.Errorf("resumed FixCount = %d, want 1", loaded.FixCount)
+	}
+
+	// Resume should be able to advance to Done
+	loaded.FixCount = 3
+	loaded.ProcessedEvents = append(loaded.ProcessedEvents, "comment-3")
+	if err := loaded.Advance(PhaseDone); err != nil {
+		t.Fatal(err)
+	}
+
+	final, err := Load(dir, 10)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if final.Phase != PhaseDone {
+		t.Errorf("final phase = %q, want \"done\"", final.Phase)
+	}
+	if final.FixCount != 3 {
+		t.Errorf("final FixCount = %d", final.FixCount)
+	}
+	if len(final.ProcessedEvents) != 3 {
+		t.Errorf("final ProcessedEvents len = %d", len(final.ProcessedEvents))
+	}
+}
+
+func TestStateJSONFormat(t *testing.T) {
+	dir := t.TempDir()
+	s := New(dir, "owner", "repo", 42)
+	s.Branch = "fleet/42"
+	s.PR = &PRInfo{Number: 100, URL: "https://github.com/owner/repo/pull/100"}
+	s.ProcessedEvents = []string{"comment-123", "review-456"}
+	s.FixCount = 2
+	s.WatchStartedAt = time.Date(2026, 3, 8, 13, 0, 0, 0, time.UTC)
+	s.LastEventAt = time.Date(2026, 3, 8, 14, 0, 0, 0, time.UTC)
+
+	if err := s.Advance(PhaseWatch); err != nil {
+		t.Fatal(err)
+	}
+
+	// Read the raw JSON file and verify expected fields are present
+	data, err := os.ReadFile(statePath(dir, 42))
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	var raw map[string]interface{}
+	if err := json.Unmarshal(data, &raw); err != nil {
+		t.Fatal(err)
+	}
+
+	if raw["phase"] != "watch" {
+		t.Errorf("JSON phase = %v", raw["phase"])
+	}
+	if raw["branch"] != "fleet/42" {
+		t.Errorf("JSON branch = %v", raw["branch"])
+	}
+
+	pr, ok := raw["pr"].(map[string]interface{})
+	if !ok {
+		t.Fatal("JSON pr should be an object")
+	}
+	if pr["number"] != float64(100) {
+		t.Errorf("JSON pr.number = %v", pr["number"])
+	}
+
+	events, ok := raw["processed_events"].([]interface{})
+	if !ok {
+		t.Fatal("JSON processed_events should be an array")
+	}
+	if len(events) != 2 {
+		t.Errorf("JSON processed_events len = %d", len(events))
+	}
+
+	if raw["fix_count"] != float64(2) {
+		t.Errorf("JSON fix_count = %v", raw["fix_count"])
+	}
+}
+
+func TestEmptyProcessedEvents(t *testing.T) {
+	dir := t.TempDir()
+	s := New(dir, "owner", "repo", 1)
+	s.Branch = "fleet/1"
+
+	if err := s.Save(); err != nil {
+		t.Fatal(err)
+	}
+
+	loaded, err := Load(dir, 1)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(loaded.ProcessedEvents) != 0 {
+		t.Errorf("ProcessedEvents should be empty, got %v", loaded.ProcessedEvents)
+	}
+	if loaded.FixCount != 0 {
+		t.Errorf("FixCount should be 0, got %d", loaded.FixCount)
+	}
+}
+
+func TestAdvanceFromImplementToPR(t *testing.T) {
+	dir := t.TempDir()
+	s := New(dir, "owner", "repo", 5)
+	s.Branch = "fleet/5"
+
+	if err := s.Advance(PhaseIntake); err != nil {
+		t.Fatal(err)
+	}
+	if err := s.Advance(PhaseImplement); err != nil {
+		t.Fatal(err)
+	}
+
+	loaded, _ := Load(dir, 5)
+	if loaded.Phase != PhaseImplement {
+		t.Errorf("phase = %q, want \"implement\"", loaded.Phase)
+	}
+
+	loaded.PR = &PRInfo{Number: 42, URL: "https://github.com/owner/repo/pull/42"}
+	if err := loaded.Advance(PhasePR); err != nil {
+		t.Fatal(err)
+	}
+
+	final, _ := Load(dir, 5)
+	if final.Phase != PhasePR {
+		t.Errorf("phase = %q, want \"pr\"", final.Phase)
+	}
+	if final.PR == nil || final.PR.Number != 42 {
+		t.Error("PR should be set after advancing to PR phase")
+	}
+}

--- a/internal/watch/events.go
+++ b/internal/watch/events.go
@@ -1,0 +1,56 @@
+package watch
+
+import (
+	"context"
+	"time"
+)
+
+// EventType classifies PR events.
+type EventType string
+
+const (
+	EventReviewComment EventType = "review_comment"
+	EventPRComment     EventType = "pr_comment"
+	EventCheckPass     EventType = "check_pass"
+	EventCheckFail     EventType = "check_fail"
+	EventMerged        EventType = "merged"
+	EventClosed        EventType = "closed"
+)
+
+// Event represents a single PR event.
+type Event struct {
+	ID        string
+	Type      EventType
+	Body      string
+	Author    string
+	CreatedAt time.Time
+}
+
+// PRState represents the current state of a PR.
+type PRState string
+
+const (
+	PROpen   PRState = "open"
+	PRMerged PRState = "merged"
+	PRClosed PRState = "closed"
+)
+
+// CheckRun represents a CI check run result.
+type CheckRun struct {
+	Name       string
+	Status     string // "completed", "in_progress", "queued"
+	Conclusion string // "success", "failure", "neutral", etc.
+	LogURL     string
+}
+
+// EventSource abstracts fetching PR events from GitHub.
+type EventSource interface {
+	// FetchComments returns comments on the PR since the given time.
+	FetchComments(ctx context.Context, owner, repo string, prNumber int, since time.Time) ([]Event, error)
+	// FetchReviews returns review comments on the PR since the given time.
+	FetchReviews(ctx context.Context, owner, repo string, prNumber int, since time.Time) ([]Event, error)
+	// FetchCheckRuns returns CI check runs for the PR.
+	FetchCheckRuns(ctx context.Context, owner, repo string, prNumber int) ([]CheckRun, error)
+	// GetPRState returns the current state of the PR.
+	GetPRState(ctx context.Context, owner, repo string, prNumber int) (PRState, error)
+}

--- a/internal/watch/events_test.go
+++ b/internal/watch/events_test.go
@@ -1,0 +1,231 @@
+package watch
+
+import (
+	"testing"
+	"time"
+)
+
+// ---------------------------------------------------------------------------
+// Event type constants
+// ---------------------------------------------------------------------------
+
+func TestEventTypeConstants(t *testing.T) {
+	tests := []struct {
+		eventType EventType
+		expected  string
+	}{
+		{EventReviewComment, "review_comment"},
+		{EventPRComment, "pr_comment"},
+		{EventCheckPass, "check_pass"},
+		{EventCheckFail, "check_fail"},
+		{EventMerged, "merged"},
+		{EventClosed, "closed"},
+	}
+	for _, tt := range tests {
+		if string(tt.eventType) != tt.expected {
+			t.Errorf("EventType = %q, want %q", tt.eventType, tt.expected)
+		}
+	}
+}
+
+// ---------------------------------------------------------------------------
+// PRState constants
+// ---------------------------------------------------------------------------
+
+func TestPRStateConstants(t *testing.T) {
+	tests := []struct {
+		state    PRState
+		expected string
+	}{
+		{PROpen, "open"},
+		{PRMerged, "merged"},
+		{PRClosed, "closed"},
+	}
+	for _, tt := range tests {
+		if string(tt.state) != tt.expected {
+			t.Errorf("PRState = %q, want %q", tt.state, tt.expected)
+		}
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Event struct
+// ---------------------------------------------------------------------------
+
+func TestEventFields(t *testing.T) {
+	now := time.Now()
+	e := Event{
+		ID:        "comment-123",
+		Type:      EventReviewComment,
+		Body:      "Please fix the variable naming",
+		Author:    "reviewer",
+		CreatedAt: now,
+	}
+
+	if e.ID != "comment-123" {
+		t.Errorf("ID = %q", e.ID)
+	}
+	if e.Type != EventReviewComment {
+		t.Errorf("Type = %q", e.Type)
+	}
+	if e.Body != "Please fix the variable naming" {
+		t.Errorf("Body = %q", e.Body)
+	}
+	if e.Author != "reviewer" {
+		t.Errorf("Author = %q", e.Author)
+	}
+	if !e.CreatedAt.Equal(now) {
+		t.Errorf("CreatedAt = %v", e.CreatedAt)
+	}
+}
+
+// ---------------------------------------------------------------------------
+// CheckRun struct
+// ---------------------------------------------------------------------------
+
+func TestCheckRunFields(t *testing.T) {
+	tests := []struct {
+		name       string
+		run        CheckRun
+		wantPassed bool
+	}{
+		{
+			name:       "successful check",
+			run:        CheckRun{Name: "build", Status: "completed", Conclusion: "success"},
+			wantPassed: true,
+		},
+		{
+			name:       "failed check",
+			run:        CheckRun{Name: "test", Status: "completed", Conclusion: "failure"},
+			wantPassed: false,
+		},
+		{
+			name:       "neutral check",
+			run:        CheckRun{Name: "lint", Status: "completed", Conclusion: "neutral"},
+			wantPassed: false,
+		},
+		{
+			name:       "in-progress check",
+			run:        CheckRun{Name: "deploy", Status: "in_progress", Conclusion: ""},
+			wantPassed: false,
+		},
+		{
+			name:       "queued check",
+			run:        CheckRun{Name: "e2e", Status: "queued", Conclusion: ""},
+			wantPassed: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			passed := tt.run.Status == "completed" && tt.run.Conclusion == "success"
+			if passed != tt.wantPassed {
+				t.Errorf("check %q: passed = %v, want %v", tt.run.Name, passed, tt.wantPassed)
+			}
+		})
+	}
+}
+
+func TestCheckRunLogURL(t *testing.T) {
+	run := CheckRun{
+		Name:       "CI",
+		Status:     "completed",
+		Conclusion: "failure",
+		LogURL:     "https://github.com/owner/repo/actions/runs/123",
+	}
+	if run.LogURL == "" {
+		t.Error("LogURL should be set for failed checks")
+	}
+}
+
+// ---------------------------------------------------------------------------
+// EventSource interface compliance
+// ---------------------------------------------------------------------------
+
+func TestMockEventSourceImplementsInterface(t *testing.T) {
+	// Compile-time check that mockEventSource implements EventSource
+	var _ EventSource = &mockEventSource{}
+}
+
+func TestDynamicMockEventSourceImplementsInterface(t *testing.T) {
+	var _ EventSource = &dynamicMockEventSource{}
+}
+
+// ---------------------------------------------------------------------------
+// Event ordering
+// ---------------------------------------------------------------------------
+
+func TestEventsChronologicalOrder(t *testing.T) {
+	now := time.Now()
+	events := []Event{
+		{ID: "1", CreatedAt: now.Add(-3 * time.Minute)},
+		{ID: "2", CreatedAt: now.Add(-2 * time.Minute)},
+		{ID: "3", CreatedAt: now.Add(-1 * time.Minute)},
+	}
+
+	for i := 1; i < len(events); i++ {
+		if !events[i].CreatedAt.After(events[i-1].CreatedAt) {
+			t.Errorf("events should be in chronological order: event %d (%v) should be after event %d (%v)",
+				i, events[i].CreatedAt, i-1, events[i-1].CreatedAt)
+		}
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Multiple check run aggregation
+// ---------------------------------------------------------------------------
+
+func TestAllChecksPassed(t *testing.T) {
+	checks := []CheckRun{
+		{Name: "build", Status: "completed", Conclusion: "success"},
+		{Name: "test", Status: "completed", Conclusion: "success"},
+		{Name: "lint", Status: "completed", Conclusion: "success"},
+	}
+
+	allPassed := true
+	for _, c := range checks {
+		if c.Status != "completed" || c.Conclusion != "success" {
+			allPassed = false
+			break
+		}
+	}
+	if !allPassed {
+		t.Error("all checks should pass")
+	}
+}
+
+func TestAnyCheckFailed(t *testing.T) {
+	checks := []CheckRun{
+		{Name: "build", Status: "completed", Conclusion: "success"},
+		{Name: "test", Status: "completed", Conclusion: "failure"},
+		{Name: "lint", Status: "completed", Conclusion: "success"},
+	}
+
+	var failed []string
+	for _, c := range checks {
+		if c.Status == "completed" && c.Conclusion == "failure" {
+			failed = append(failed, c.Name)
+		}
+	}
+	if len(failed) != 1 || failed[0] != "test" {
+		t.Errorf("expected [test] to be failed, got %v", failed)
+	}
+}
+
+func TestChecksStillPending(t *testing.T) {
+	checks := []CheckRun{
+		{Name: "build", Status: "completed", Conclusion: "success"},
+		{Name: "test", Status: "in_progress", Conclusion: ""},
+	}
+
+	allCompleted := true
+	for _, c := range checks {
+		if c.Status != "completed" {
+			allCompleted = false
+			break
+		}
+	}
+	if allCompleted {
+		t.Error("not all checks should be completed")
+	}
+}

--- a/internal/watch/handler.go
+++ b/internal/watch/handler.go
@@ -1,0 +1,31 @@
+package watch
+
+import (
+	"context"
+)
+
+// Action represents what the agent should do in response to an event.
+type Action string
+
+const (
+	ActionReply    Action = "reply"      // Reply to comment only
+	ActionFix      Action = "fix"        // Fix code and push
+	ActionFixReply Action = "fix_reply"  // Fix code, push, and reply
+	ActionNothing  Action = "nothing"    // No action needed
+)
+
+// Decision is the handler's decision for how to respond to an event.
+type Decision struct {
+	Action  Action
+	Message string // Reply message or commit message
+}
+
+// Agent abstracts the code agent for analyzing, fixing, and replying.
+type Agent interface {
+	// Decide analyzes the event context and returns a decision on what to do.
+	Decide(ctx context.Context, event Event, prDiff string, history []Event) (*Decision, error)
+	// Fix applies a code fix based on the prompt and pushes the changes.
+	Fix(ctx context.Context, workdir, branch, prompt string) error
+	// Reply posts a comment on the PR.
+	Reply(ctx context.Context, owner, repo string, prNumber int, body string) error
+}

--- a/internal/watch/handler_test.go
+++ b/internal/watch/handler_test.go
@@ -1,0 +1,638 @@
+package watch
+
+import (
+	"context"
+	"testing"
+	"time"
+)
+
+// ---------------------------------------------------------------------------
+// Action and Decision constants
+// ---------------------------------------------------------------------------
+
+func TestActionConstants(t *testing.T) {
+	tests := []struct {
+		action   Action
+		expected string
+	}{
+		{ActionReply, "reply"},
+		{ActionFix, "fix"},
+		{ActionFixReply, "fix_reply"},
+		{ActionNothing, "nothing"},
+	}
+	for _, tt := range tests {
+		if string(tt.action) != tt.expected {
+			t.Errorf("Action = %q, want %q", tt.action, tt.expected)
+		}
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Agent interface compliance
+// ---------------------------------------------------------------------------
+
+func TestMockAgentImplementsInterface(t *testing.T) {
+	var _ Agent = &mockAgent{}
+}
+
+// ---------------------------------------------------------------------------
+// ProcessEvent dispatch tests
+// These verify that ProcessEvent correctly dispatches the agent's decision.
+// ---------------------------------------------------------------------------
+
+func TestProcessEventFixAction(t *testing.T) {
+	agent := &mockAgent{
+		decideFn: func(_ Event) (*Decision, error) {
+			return &Decision{Action: ActionFix, Message: "Fixed the typo in variable name"}, nil
+		},
+	}
+
+	w := &Watcher{
+		Owner:           "owner",
+		Repo:            "repo",
+		PRNumber:        42,
+		Branch:          "fleet/42",
+		Workdir:         "/work",
+		Source:          &mockEventSource{prState: PROpen},
+		Agent:           agent,
+		ProcessedEvents: make(map[string]bool),
+	}
+
+	event := Event{
+		ID:   "review-1",
+		Type: EventReviewComment,
+		Body: "There's a typo in the variable name on line 15",
+	}
+
+	decision, err := w.ProcessEvent(context.Background(), event)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if decision.Action != ActionFix {
+		t.Errorf("action = %q, want %q", decision.Action, ActionFix)
+	}
+	if len(agent.fixCalls) != 1 {
+		t.Errorf("expected 1 fix call, got %d", len(agent.fixCalls))
+	}
+}
+
+func TestProcessEventReplyAction(t *testing.T) {
+	agent := &mockAgent{
+		decideFn: func(_ Event) (*Decision, error) {
+			return &Decision{Action: ActionReply, Message: "The current implementation handles this case via the fallback in line 42"}, nil
+		},
+	}
+
+	w := &Watcher{
+		Owner:           "owner",
+		Repo:            "repo",
+		PRNumber:        42,
+		Branch:          "fleet/42",
+		Workdir:         "/work",
+		Source:          &mockEventSource{prState: PROpen},
+		Agent:           agent,
+		ProcessedEvents: make(map[string]bool),
+	}
+
+	event := Event{
+		ID:   "review-2",
+		Type: EventReviewComment,
+		Body: "Why did you choose this approach over using a map?",
+	}
+
+	decision, err := w.ProcessEvent(context.Background(), event)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if decision.Action != ActionReply {
+		t.Errorf("action = %q, want %q", decision.Action, ActionReply)
+	}
+	if len(agent.replyCalls) != 1 {
+		t.Errorf("expected 1 reply call, got %d", len(agent.replyCalls))
+	}
+	// Fix should NOT be called for reply-only actions
+	if len(agent.fixCalls) != 0 {
+		t.Errorf("fix should not be called for reply-only, got %d calls", len(agent.fixCalls))
+	}
+}
+
+func TestProcessEventFixReplyAction(t *testing.T) {
+	agent := &mockAgent{
+		decideFn: func(_ Event) (*Decision, error) {
+			return &Decision{Action: ActionFixReply, Message: "Fixed in abc123"}, nil
+		},
+	}
+
+	w := &Watcher{
+		Owner:           "owner",
+		Repo:            "repo",
+		PRNumber:        42,
+		Branch:          "fleet/42",
+		Workdir:         "/work",
+		Source:          &mockEventSource{prState: PROpen},
+		Agent:           agent,
+		ProcessedEvents: make(map[string]bool),
+	}
+
+	event := Event{
+		ID:   "review-3",
+		Type: EventReviewComment,
+		Body: "This function should validate its input",
+	}
+
+	decision, err := w.ProcessEvent(context.Background(), event)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if decision.Action != ActionFixReply {
+		t.Errorf("action = %q, want %q", decision.Action, ActionFixReply)
+	}
+	// Both fix and reply should be called
+	if len(agent.fixCalls) != 1 {
+		t.Errorf("expected 1 fix call, got %d", len(agent.fixCalls))
+	}
+	if len(agent.replyCalls) != 1 {
+		t.Errorf("expected 1 reply call, got %d", len(agent.replyCalls))
+	}
+}
+
+func TestProcessEventNothingAction(t *testing.T) {
+	agent := &mockAgent{
+		decideFn: func(_ Event) (*Decision, error) {
+			return &Decision{Action: ActionNothing}, nil
+		},
+	}
+
+	w := &Watcher{
+		Owner:           "owner",
+		Repo:            "repo",
+		PRNumber:        42,
+		Branch:          "fleet/42",
+		Workdir:         "/work",
+		Source:          &mockEventSource{prState: PROpen},
+		Agent:           agent,
+		ProcessedEvents: make(map[string]bool),
+	}
+
+	event := Event{
+		ID:   "comment-1",
+		Type: EventPRComment,
+		Body: "LGTM",
+	}
+
+	decision, err := w.ProcessEvent(context.Background(), event)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if decision.Action != ActionNothing {
+		t.Errorf("action = %q, want %q", decision.Action, ActionNothing)
+	}
+	if len(agent.fixCalls) != 0 {
+		t.Errorf("fix should not be called, got %d calls", len(agent.fixCalls))
+	}
+	if len(agent.replyCalls) != 0 {
+		t.Errorf("reply should not be called, got %d calls", len(agent.replyCalls))
+	}
+}
+
+// ---------------------------------------------------------------------------
+// ProcessEvent state management
+// ---------------------------------------------------------------------------
+
+func TestProcessEventIncrementsFixCount(t *testing.T) {
+	agent := &mockAgent{
+		decideFn: func(_ Event) (*Decision, error) {
+			return &Decision{Action: ActionFix, Message: "fixing"}, nil
+		},
+	}
+
+	w := &Watcher{
+		Owner:           "owner",
+		Repo:            "repo",
+		PRNumber:        42,
+		Branch:          "fleet/42",
+		Workdir:         "/work",
+		Source:          &mockEventSource{prState: PROpen},
+		Agent:           agent,
+		ProcessedEvents: make(map[string]bool),
+		FixCount:        0,
+	}
+
+	event := Event{ID: "review-1", Type: EventReviewComment, Body: "Fix this"}
+	_, err := w.ProcessEvent(context.Background(), event)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if w.FixCount != 1 {
+		t.Errorf("FixCount = %d, want 1", w.FixCount)
+	}
+}
+
+func TestProcessEventReplyDoesNotIncrementFixCount(t *testing.T) {
+	agent := &mockAgent{
+		decideFn: func(_ Event) (*Decision, error) {
+			return &Decision{Action: ActionReply, Message: "explanation"}, nil
+		},
+	}
+
+	w := &Watcher{
+		Owner:           "owner",
+		Repo:            "repo",
+		PRNumber:        42,
+		Branch:          "fleet/42",
+		Workdir:         "/work",
+		Source:          &mockEventSource{prState: PROpen},
+		Agent:           agent,
+		ProcessedEvents: make(map[string]bool),
+		FixCount:        1,
+	}
+
+	event := Event{ID: "review-1", Type: EventReviewComment, Body: "Question"}
+	_, err := w.ProcessEvent(context.Background(), event)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if w.FixCount != 1 {
+		t.Errorf("FixCount = %d, want 1 (reply should not increment)", w.FixCount)
+	}
+}
+
+func TestProcessEventMarksProcessed(t *testing.T) {
+	agent := &mockAgent{
+		decideFn: func(_ Event) (*Decision, error) {
+			return &Decision{Action: ActionNothing}, nil
+		},
+	}
+
+	w := &Watcher{
+		Owner:           "owner",
+		Repo:            "repo",
+		PRNumber:        42,
+		Branch:          "fleet/42",
+		Workdir:         "/work",
+		Source:          &mockEventSource{prState: PROpen},
+		Agent:           agent,
+		ProcessedEvents: make(map[string]bool),
+	}
+
+	event := Event{ID: "comment-42", Type: EventPRComment, Body: "test"}
+	_, err := w.ProcessEvent(context.Background(), event)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if !w.IsProcessed("comment-42") {
+		t.Error("event should be marked as processed after ProcessEvent")
+	}
+}
+
+func TestProcessEventUpdatesLastEventTime(t *testing.T) {
+	agent := &mockAgent{
+		decideFn: func(_ Event) (*Decision, error) {
+			return &Decision{Action: ActionNothing}, nil
+		},
+	}
+
+	past := time.Now().Add(-1 * time.Hour)
+	w := &Watcher{
+		Owner:           "owner",
+		Repo:            "repo",
+		PRNumber:        42,
+		Branch:          "fleet/42",
+		Workdir:         "/work",
+		Source:          &mockEventSource{prState: PROpen},
+		Agent:           agent,
+		ProcessedEvents: make(map[string]bool),
+		LastEventAt:     past,
+	}
+
+	event := Event{ID: "comment-1", Type: EventPRComment, Body: "test", CreatedAt: time.Now()}
+	_, err := w.ProcessEvent(context.Background(), event)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if !w.LastEventAt.After(past) {
+		t.Error("LastEventAt should be updated after processing an event")
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Event type handling scenarios (verifying "think before acting" principle)
+// ---------------------------------------------------------------------------
+
+func TestHandleReviewComment_ActionableSuggestion(t *testing.T) {
+	// "Reasonable suggestion → Fix code, reply 'Fixed in <commit>'"
+	agent := &mockAgent{
+		decideFn: func(e Event) (*Decision, error) {
+			if e.Type == EventReviewComment {
+				return &Decision{Action: ActionFixReply, Message: "Fixed in abc1234"}, nil
+			}
+			return &Decision{Action: ActionNothing}, nil
+		},
+	}
+
+	w := &Watcher{
+		Owner:           "owner",
+		Repo:            "repo",
+		PRNumber:        42,
+		Branch:          "fleet/42",
+		Workdir:         "/work",
+		Source:          &mockEventSource{prState: PROpen},
+		Agent:           agent,
+		ProcessedEvents: make(map[string]bool),
+	}
+
+	event := Event{
+		ID:   "review-1",
+		Type: EventReviewComment,
+		Body: "This variable should be renamed to follow Go conventions",
+	}
+
+	decision, err := w.ProcessEvent(context.Background(), event)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if decision.Action != ActionFixReply {
+		t.Errorf("actionable suggestion should result in fix_reply, got %q", decision.Action)
+	}
+}
+
+func TestHandleReviewComment_DiscussionQuestion(t *testing.T) {
+	// "Discussion/question → Reply with explanation, don't change code"
+	agent := &mockAgent{
+		decideFn: func(e Event) (*Decision, error) {
+			if e.Type == EventReviewComment {
+				return &Decision{Action: ActionReply, Message: "Good question. I used a slice here because..."}, nil
+			}
+			return &Decision{Action: ActionNothing}, nil
+		},
+	}
+
+	w := &Watcher{
+		Owner:           "owner",
+		Repo:            "repo",
+		PRNumber:        42,
+		Branch:          "fleet/42",
+		Workdir:         "/work",
+		Source:          &mockEventSource{prState: PROpen},
+		Agent:           agent,
+		ProcessedEvents: make(map[string]bool),
+	}
+
+	event := Event{
+		ID:   "review-2",
+		Type: EventReviewComment,
+		Body: "Why did you choose a slice instead of a map here?",
+	}
+
+	decision, err := w.ProcessEvent(context.Background(), event)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if decision.Action != ActionReply {
+		t.Errorf("discussion should result in reply only, got %q", decision.Action)
+	}
+	if len(agent.fixCalls) != 0 {
+		t.Error("discussion should not trigger a code fix")
+	}
+}
+
+func TestHandleCIFailure_OwnCode(t *testing.T) {
+	// "CI failure from own code → Fix"
+	agent := &mockAgent{
+		decideFn: func(e Event) (*Decision, error) {
+			if e.Type == EventCheckFail {
+				return &Decision{Action: ActionFix, Message: "Fix CI failure: missing import"}, nil
+			}
+			return &Decision{Action: ActionNothing}, nil
+		},
+	}
+
+	w := &Watcher{
+		Owner:           "owner",
+		Repo:            "repo",
+		PRNumber:        42,
+		Branch:          "fleet/42",
+		Workdir:         "/work",
+		Source:          &mockEventSource{prState: PROpen},
+		Agent:           agent,
+		ProcessedEvents: make(map[string]bool),
+	}
+
+	event := Event{
+		ID:   "check-1",
+		Type: EventCheckFail,
+		Body: "Build failed: undefined reference to 'NewWatcher'",
+	}
+
+	decision, err := w.ProcessEvent(context.Background(), event)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if decision.Action != ActionFix {
+		t.Errorf("CI failure from own code should result in fix, got %q", decision.Action)
+	}
+	if len(agent.fixCalls) != 1 {
+		t.Errorf("expected 1 fix call, got %d", len(agent.fixCalls))
+	}
+}
+
+func TestHandleCIFailure_FlakyTest(t *testing.T) {
+	// "CI failure from flaky test / environment → Explain, don't change"
+	agent := &mockAgent{
+		decideFn: func(e Event) (*Decision, error) {
+			if e.Type == EventCheckFail {
+				return &Decision{Action: ActionReply, Message: "This appears to be a flaky test unrelated to my changes"}, nil
+			}
+			return &Decision{Action: ActionNothing}, nil
+		},
+	}
+
+	w := &Watcher{
+		Owner:           "owner",
+		Repo:            "repo",
+		PRNumber:        42,
+		Branch:          "fleet/42",
+		Workdir:         "/work",
+		Source:          &mockEventSource{prState: PROpen},
+		Agent:           agent,
+		ProcessedEvents: make(map[string]bool),
+	}
+
+	event := Event{
+		ID:   "check-2",
+		Type: EventCheckFail,
+		Body: "Test timeout: network connection refused (flaky)",
+	}
+
+	decision, err := w.ProcessEvent(context.Background(), event)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if decision.Action != ActionReply {
+		t.Errorf("flaky test should result in reply (explain), got %q", decision.Action)
+	}
+	if len(agent.fixCalls) != 0 {
+		t.Error("flaky test should not trigger a code fix")
+	}
+}
+
+func TestHandleCIPass_Summary(t *testing.T) {
+	// "CI pass → Comment summary"
+	agent := &mockAgent{
+		decideFn: func(e Event) (*Decision, error) {
+			if e.Type == EventCheckPass {
+				return &Decision{Action: ActionReply, Message: "All CI checks passing"}, nil
+			}
+			return &Decision{Action: ActionNothing}, nil
+		},
+	}
+
+	w := &Watcher{
+		Owner:           "owner",
+		Repo:            "repo",
+		PRNumber:        42,
+		Branch:          "fleet/42",
+		Workdir:         "/work",
+		Source:          &mockEventSource{prState: PROpen},
+		Agent:           agent,
+		ProcessedEvents: make(map[string]bool),
+	}
+
+	event := Event{
+		ID:   "check-3",
+		Type: EventCheckPass,
+		Body: "All checks passed",
+	}
+
+	decision, err := w.ProcessEvent(context.Background(), event)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if decision.Action != ActionReply {
+		t.Errorf("CI pass should result in reply (summary), got %q", decision.Action)
+	}
+}
+
+func TestHandleCIFailure_Unrelated(t *testing.T) {
+	// "CI failure unrelated → Ignore"
+	agent := &mockAgent{
+		decideFn: func(e Event) (*Decision, error) {
+			return &Decision{Action: ActionNothing}, nil
+		},
+	}
+
+	w := &Watcher{
+		Owner:           "owner",
+		Repo:            "repo",
+		PRNumber:        42,
+		Branch:          "fleet/42",
+		Workdir:         "/work",
+		Source:          &mockEventSource{prState: PROpen},
+		Agent:           agent,
+		ProcessedEvents: make(map[string]bool),
+	}
+
+	event := Event{
+		ID:   "check-4",
+		Type: EventCheckFail,
+		Body: "Deploy to staging failed: infrastructure issue",
+	}
+
+	decision, err := w.ProcessEvent(context.Background(), event)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if decision.Action != ActionNothing {
+		t.Errorf("unrelated CI failure should be ignored, got %q", decision.Action)
+	}
+	if len(agent.fixCalls) != 0 {
+		t.Error("unrelated CI failure should not trigger a fix")
+	}
+	if len(agent.replyCalls) != 0 {
+		t.Error("unrelated CI failure should not trigger a reply")
+	}
+}
+
+func TestHandlePRComment(t *testing.T) {
+	// PR comments (not review comments) should also be processed
+	agent := &mockAgent{
+		decideFn: func(e Event) (*Decision, error) {
+			if e.Type == EventPRComment {
+				return &Decision{Action: ActionReply, Message: "Thanks for the feedback!"}, nil
+			}
+			return &Decision{Action: ActionNothing}, nil
+		},
+	}
+
+	w := &Watcher{
+		Owner:           "owner",
+		Repo:            "repo",
+		PRNumber:        42,
+		Branch:          "fleet/42",
+		Workdir:         "/work",
+		Source:          &mockEventSource{prState: PROpen},
+		Agent:           agent,
+		ProcessedEvents: make(map[string]bool),
+	}
+
+	event := Event{
+		ID:     "comment-1",
+		Type:   EventPRComment,
+		Body:   "Can you also add a test for the edge case?",
+		Author: "maintainer",
+	}
+
+	decision, err := w.ProcessEvent(context.Background(), event)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if decision.Action != ActionReply {
+		t.Errorf("PR comment should be handled, got action %q", decision.Action)
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Multiple fixes tracking
+// ---------------------------------------------------------------------------
+
+func TestMultipleFixesIncrementCount(t *testing.T) {
+	fixCount := 0
+	agent := &mockAgent{
+		decideFn: func(_ Event) (*Decision, error) {
+			return &Decision{Action: ActionFix, Message: "fixing"}, nil
+		},
+	}
+
+	w := &Watcher{
+		Owner:           "owner",
+		Repo:            "repo",
+		PRNumber:        42,
+		Branch:          "fleet/42",
+		Workdir:         "/work",
+		Source:          &mockEventSource{prState: PROpen},
+		Agent:           agent,
+		ProcessedEvents: make(map[string]bool),
+		FixCount:        fixCount,
+	}
+
+	events := []Event{
+		{ID: "r-1", Type: EventReviewComment, Body: "Fix 1"},
+		{ID: "r-2", Type: EventReviewComment, Body: "Fix 2"},
+		{ID: "r-3", Type: EventReviewComment, Body: "Fix 3"},
+	}
+
+	for _, e := range events {
+		_, err := w.ProcessEvent(context.Background(), e)
+		if err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	if w.FixCount != 3 {
+		t.Errorf("FixCount = %d, want 3 after 3 fixes", w.FixCount)
+	}
+}

--- a/internal/watch/watch.go
+++ b/internal/watch/watch.go
@@ -1,0 +1,113 @@
+package watch
+
+import (
+	"context"
+	"fmt"
+	"time"
+)
+
+// ExitReason describes why the watch loop exited.
+type ExitReason string
+
+const (
+	ExitMerged   ExitReason = "merged"
+	ExitClosed   ExitReason = "closed"
+	ExitTimeout  ExitReason = "timeout"
+	ExitIdle     ExitReason = "idle"
+	ExitMaxFixes ExitReason = "max_fixes"
+)
+
+// Result is returned when the watch loop exits.
+type Result struct {
+	Reason ExitReason
+}
+
+// Config holds watch loop configuration.
+type Config struct {
+	PollInterval time.Duration
+	Timeout      time.Duration
+	IdleTimeout  time.Duration
+	MaxFixRounds int
+}
+
+// Watcher monitors a PR for events and responds to them.
+type Watcher struct {
+	Owner    string
+	Repo     string
+	PRNumber int
+	Branch   string
+	Workdir  string
+	Config   Config
+	Source   EventSource
+	Agent    Agent
+
+	// State tracking
+	ProcessedEvents map[string]bool
+	FixCount        int
+	LastEventAt     time.Time
+	StartedAt       time.Time
+}
+
+// NewWatcher creates a new Watcher with the given configuration.
+func NewWatcher(owner, repo string, prNumber int, branch, workdir string, cfg Config, source EventSource, agent Agent) *Watcher {
+	now := time.Now()
+	return &Watcher{
+		Owner:           owner,
+		Repo:            repo,
+		PRNumber:        prNumber,
+		Branch:          branch,
+		Workdir:         workdir,
+		Config:          cfg,
+		Source:          source,
+		Agent:           agent,
+		ProcessedEvents: make(map[string]bool),
+		StartedAt:       now,
+		LastEventAt:     now,
+	}
+}
+
+// Run starts the watch loop. It polls for new events and processes them
+// until the PR is merged, closed, or a timeout is reached.
+func (w *Watcher) Run(ctx context.Context) (*Result, error) {
+	return nil, fmt.Errorf("not implemented")
+}
+
+// ProcessEvent handles a single event and returns the action taken.
+func (w *Watcher) ProcessEvent(ctx context.Context, event Event) (*Decision, error) {
+	return nil, fmt.Errorf("not implemented")
+}
+
+// IsProcessed returns true if the event has already been processed.
+func (w *Watcher) IsProcessed(eventID string) bool {
+	return w.ProcessedEvents[eventID]
+}
+
+// MarkProcessed marks an event as processed.
+func (w *Watcher) MarkProcessed(eventID string) {
+	w.ProcessedEvents[eventID] = true
+}
+
+// ShouldExit checks if the watch loop should exit based on timeouts or fix limits.
+func (w *Watcher) ShouldExit() (ExitReason, bool) {
+	if time.Since(w.StartedAt) > w.Config.Timeout {
+		return ExitTimeout, true
+	}
+	if time.Since(w.LastEventAt) > w.Config.IdleTimeout {
+		return ExitIdle, true
+	}
+	if w.FixCount >= w.Config.MaxFixRounds {
+		return ExitMaxFixes, true
+	}
+	return "", false
+}
+
+// FilterNewEvents returns only events that haven't been processed yet.
+func (w *Watcher) FilterNewEvents(events []Event) []Event {
+	var filtered []Event
+	for _, e := range events {
+		if !w.IsProcessed(e.ID) {
+			filtered = append(filtered, e)
+		}
+	}
+	return filtered
+}

--- a/internal/watch/watch_test.go
+++ b/internal/watch/watch_test.go
@@ -1,0 +1,670 @@
+package watch
+
+import (
+	"context"
+	"fmt"
+	"testing"
+	"time"
+)
+
+// ---------------------------------------------------------------------------
+// Test doubles
+// ---------------------------------------------------------------------------
+
+type mockEventSource struct {
+	comments []Event
+	reviews  []Event
+	checks   []CheckRun
+	prState  PRState
+	fetchErr error
+}
+
+func (m *mockEventSource) FetchComments(_ context.Context, _, _ string, _ int, _ time.Time) ([]Event, error) {
+	if m.fetchErr != nil {
+		return nil, m.fetchErr
+	}
+	return m.comments, nil
+}
+
+func (m *mockEventSource) FetchReviews(_ context.Context, _, _ string, _ int, _ time.Time) ([]Event, error) {
+	if m.fetchErr != nil {
+		return nil, m.fetchErr
+	}
+	return m.reviews, nil
+}
+
+func (m *mockEventSource) FetchCheckRuns(_ context.Context, _, _ string, _ int) ([]CheckRun, error) {
+	if m.fetchErr != nil {
+		return nil, m.fetchErr
+	}
+	return m.checks, nil
+}
+
+func (m *mockEventSource) GetPRState(_ context.Context, _, _ string, _ int) (PRState, error) {
+	return m.prState, nil
+}
+
+// dynamicMockEventSource generates new events on each call for testing loops.
+type dynamicMockEventSource struct {
+	prStateFn  func() PRState
+	commentsFn func() []Event
+	reviewsFn  func() []Event
+	checksFn   func() []CheckRun
+}
+
+func (d *dynamicMockEventSource) FetchComments(_ context.Context, _, _ string, _ int, _ time.Time) ([]Event, error) {
+	if d.commentsFn != nil {
+		return d.commentsFn(), nil
+	}
+	return nil, nil
+}
+
+func (d *dynamicMockEventSource) FetchReviews(_ context.Context, _, _ string, _ int, _ time.Time) ([]Event, error) {
+	if d.reviewsFn != nil {
+		return d.reviewsFn(), nil
+	}
+	return nil, nil
+}
+
+func (d *dynamicMockEventSource) FetchCheckRuns(_ context.Context, _, _ string, _ int) ([]CheckRun, error) {
+	if d.checksFn != nil {
+		return d.checksFn(), nil
+	}
+	return nil, nil
+}
+
+func (d *dynamicMockEventSource) GetPRState(_ context.Context, _, _ string, _ int) (PRState, error) {
+	if d.prStateFn != nil {
+		return d.prStateFn(), nil
+	}
+	return PROpen, nil
+}
+
+type mockAgent struct {
+	decideFn   func(event Event) (*Decision, error)
+	fixCalls   []string
+	replyCalls []string
+	fixErr     error
+	replyErr   error
+}
+
+func (m *mockAgent) Decide(_ context.Context, event Event, _ string, _ []Event) (*Decision, error) {
+	if m.decideFn != nil {
+		return m.decideFn(event)
+	}
+	return &Decision{Action: ActionNothing}, nil
+}
+
+func (m *mockAgent) Fix(_ context.Context, _, _, prompt string) error {
+	m.fixCalls = append(m.fixCalls, prompt)
+	return m.fixErr
+}
+
+func (m *mockAgent) Reply(_ context.Context, _, _ string, _ int, body string) error {
+	m.replyCalls = append(m.replyCalls, body)
+	return m.replyErr
+}
+
+// ---------------------------------------------------------------------------
+// Constructor tests
+// ---------------------------------------------------------------------------
+
+func TestNewWatcher(t *testing.T) {
+	cfg := Config{
+		PollInterval: 30 * time.Second,
+		Timeout:      2 * time.Hour,
+		IdleTimeout:  30 * time.Minute,
+		MaxFixRounds: 5,
+	}
+	source := &mockEventSource{}
+	agent := &mockAgent{}
+
+	w := NewWatcher("owner", "repo", 42, "fleet/42", "/work", cfg, source, agent)
+
+	if w.Owner != "owner" {
+		t.Errorf("Owner = %q, want \"owner\"", w.Owner)
+	}
+	if w.Repo != "repo" {
+		t.Errorf("Repo = %q, want \"repo\"", w.Repo)
+	}
+	if w.PRNumber != 42 {
+		t.Errorf("PRNumber = %d, want 42", w.PRNumber)
+	}
+	if w.Branch != "fleet/42" {
+		t.Errorf("Branch = %q, want \"fleet/42\"", w.Branch)
+	}
+	if w.Workdir != "/work" {
+		t.Errorf("Workdir = %q, want \"/work\"", w.Workdir)
+	}
+	if w.Config.MaxFixRounds != 5 {
+		t.Errorf("MaxFixRounds = %d, want 5", w.Config.MaxFixRounds)
+	}
+	if w.ProcessedEvents == nil {
+		t.Error("ProcessedEvents should be initialized")
+	}
+	if len(w.ProcessedEvents) != 0 {
+		t.Errorf("ProcessedEvents should be empty, got %d", len(w.ProcessedEvents))
+	}
+	if w.FixCount != 0 {
+		t.Errorf("FixCount = %d, want 0", w.FixCount)
+	}
+	if w.StartedAt.IsZero() {
+		t.Error("StartedAt should be set")
+	}
+	if w.LastEventAt.IsZero() {
+		t.Error("LastEventAt should be set")
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Event tracking
+// ---------------------------------------------------------------------------
+
+func TestIsProcessed(t *testing.T) {
+	w := &Watcher{ProcessedEvents: make(map[string]bool)}
+
+	if w.IsProcessed("event-1") {
+		t.Error("event-1 should not be processed initially")
+	}
+
+	w.MarkProcessed("event-1")
+
+	if !w.IsProcessed("event-1") {
+		t.Error("event-1 should be processed after MarkProcessed")
+	}
+	if w.IsProcessed("event-2") {
+		t.Error("event-2 should not be processed")
+	}
+}
+
+func TestMarkProcessedIdempotent(t *testing.T) {
+	w := &Watcher{ProcessedEvents: make(map[string]bool)}
+	w.MarkProcessed("event-1")
+	w.MarkProcessed("event-1") // second call should not panic or change state
+
+	if !w.IsProcessed("event-1") {
+		t.Error("event-1 should still be processed")
+	}
+	if len(w.ProcessedEvents) != 1 {
+		t.Errorf("should have 1 processed event, got %d", len(w.ProcessedEvents))
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Event filtering
+// ---------------------------------------------------------------------------
+
+func TestFilterNewEvents(t *testing.T) {
+	w := &Watcher{ProcessedEvents: map[string]bool{
+		"event-1": true,
+		"event-3": true,
+	}}
+
+	events := []Event{
+		{ID: "event-1", Type: EventPRComment, Body: "first"},
+		{ID: "event-2", Type: EventPRComment, Body: "second"},
+		{ID: "event-3", Type: EventReviewComment, Body: "third"},
+		{ID: "event-4", Type: EventReviewComment, Body: "fourth"},
+	}
+
+	filtered := w.FilterNewEvents(events)
+
+	if len(filtered) != 2 {
+		t.Fatalf("got %d events, want 2", len(filtered))
+	}
+	if filtered[0].ID != "event-2" {
+		t.Errorf("filtered[0].ID = %q, want \"event-2\"", filtered[0].ID)
+	}
+	if filtered[1].ID != "event-4" {
+		t.Errorf("filtered[1].ID = %q, want \"event-4\"", filtered[1].ID)
+	}
+}
+
+func TestFilterNewEventsNone(t *testing.T) {
+	w := &Watcher{ProcessedEvents: map[string]bool{
+		"event-1": true,
+	}}
+
+	events := []Event{
+		{ID: "event-1", Type: EventPRComment},
+	}
+
+	filtered := w.FilterNewEvents(events)
+	if len(filtered) != 0 {
+		t.Errorf("expected 0 new events, got %d", len(filtered))
+	}
+}
+
+func TestFilterNewEventsEmpty(t *testing.T) {
+	w := &Watcher{ProcessedEvents: make(map[string]bool)}
+	filtered := w.FilterNewEvents(nil)
+	if filtered != nil {
+		t.Errorf("filtering nil should return nil, got %v", filtered)
+	}
+}
+
+func TestFilterNewEventsAllNew(t *testing.T) {
+	w := &Watcher{ProcessedEvents: make(map[string]bool)}
+
+	events := []Event{
+		{ID: "event-1"},
+		{ID: "event-2"},
+	}
+
+	filtered := w.FilterNewEvents(events)
+	if len(filtered) != 2 {
+		t.Errorf("expected 2 new events, got %d", len(filtered))
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Exit conditions
+// ---------------------------------------------------------------------------
+
+func TestShouldExitTimeout(t *testing.T) {
+	w := &Watcher{
+		Config: Config{
+			Timeout:      1 * time.Hour,
+			IdleTimeout:  30 * time.Minute,
+			MaxFixRounds: 5,
+		},
+		StartedAt:   time.Now().Add(-2 * time.Hour),
+		LastEventAt: time.Now(),
+		FixCount:    0,
+	}
+
+	reason, shouldExit := w.ShouldExit()
+	if !shouldExit {
+		t.Error("should exit due to timeout")
+	}
+	if reason != ExitTimeout {
+		t.Errorf("reason = %q, want %q", reason, ExitTimeout)
+	}
+}
+
+func TestShouldExitIdleTimeout(t *testing.T) {
+	w := &Watcher{
+		Config: Config{
+			Timeout:      2 * time.Hour,
+			IdleTimeout:  30 * time.Minute,
+			MaxFixRounds: 5,
+		},
+		StartedAt:   time.Now().Add(-1 * time.Hour),
+		LastEventAt: time.Now().Add(-45 * time.Minute),
+		FixCount:    0,
+	}
+
+	reason, shouldExit := w.ShouldExit()
+	if !shouldExit {
+		t.Error("should exit due to idle timeout")
+	}
+	if reason != ExitIdle {
+		t.Errorf("reason = %q, want %q", reason, ExitIdle)
+	}
+}
+
+func TestShouldExitMaxFixes(t *testing.T) {
+	w := &Watcher{
+		Config: Config{
+			Timeout:      2 * time.Hour,
+			IdleTimeout:  30 * time.Minute,
+			MaxFixRounds: 5,
+		},
+		StartedAt:   time.Now(),
+		LastEventAt: time.Now(),
+		FixCount:    5,
+	}
+
+	reason, shouldExit := w.ShouldExit()
+	if !shouldExit {
+		t.Error("should exit due to max fix rounds")
+	}
+	if reason != ExitMaxFixes {
+		t.Errorf("reason = %q, want %q", reason, ExitMaxFixes)
+	}
+}
+
+func TestShouldNotExit(t *testing.T) {
+	w := &Watcher{
+		Config: Config{
+			Timeout:      2 * time.Hour,
+			IdleTimeout:  30 * time.Minute,
+			MaxFixRounds: 5,
+		},
+		StartedAt:   time.Now(),
+		LastEventAt: time.Now(),
+		FixCount:    2,
+	}
+
+	_, shouldExit := w.ShouldExit()
+	if shouldExit {
+		t.Error("should not exit yet")
+	}
+}
+
+func TestShouldExitTimeoutPriority(t *testing.T) {
+	// When both timeout and idle timeout are exceeded, timeout takes priority
+	w := &Watcher{
+		Config: Config{
+			Timeout:      1 * time.Hour,
+			IdleTimeout:  30 * time.Minute,
+			MaxFixRounds: 5,
+		},
+		StartedAt:   time.Now().Add(-2 * time.Hour),
+		LastEventAt: time.Now().Add(-1 * time.Hour),
+		FixCount:    0,
+	}
+
+	reason, shouldExit := w.ShouldExit()
+	if !shouldExit {
+		t.Error("should exit")
+	}
+	if reason != ExitTimeout {
+		t.Errorf("reason = %q, want %q (timeout should have priority)", reason, ExitTimeout)
+	}
+}
+
+func TestShouldExitMaxFixesExact(t *testing.T) {
+	// When fix count exactly equals max, should exit
+	w := &Watcher{
+		Config: Config{
+			Timeout:      2 * time.Hour,
+			IdleTimeout:  30 * time.Minute,
+			MaxFixRounds: 3,
+		},
+		StartedAt:   time.Now(),
+		LastEventAt: time.Now(),
+		FixCount:    3,
+	}
+
+	reason, shouldExit := w.ShouldExit()
+	if !shouldExit {
+		t.Error("should exit when fix count equals max")
+	}
+	if reason != ExitMaxFixes {
+		t.Errorf("reason = %q, want %q", reason, ExitMaxFixes)
+	}
+}
+
+func TestShouldNotExitBelowMax(t *testing.T) {
+	w := &Watcher{
+		Config: Config{
+			Timeout:      2 * time.Hour,
+			IdleTimeout:  30 * time.Minute,
+			MaxFixRounds: 3,
+		},
+		StartedAt:   time.Now(),
+		LastEventAt: time.Now(),
+		FixCount:    2,
+	}
+
+	_, shouldExit := w.ShouldExit()
+	if shouldExit {
+		t.Error("should not exit when fix count is below max")
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Watch loop exit conditions (integration-level tests)
+// These test the full Run() loop behavior.
+// ---------------------------------------------------------------------------
+
+func TestWatcherExitOnMerge(t *testing.T) {
+	source := &mockEventSource{prState: PRMerged}
+	agent := &mockAgent{}
+
+	w := NewWatcher("owner", "repo", 1, "fleet/1", "/work", Config{
+		PollInterval: 10 * time.Millisecond,
+		Timeout:      1 * time.Hour,
+		IdleTimeout:  30 * time.Minute,
+		MaxFixRounds: 5,
+	}, source, agent)
+
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+
+	result, err := w.Run(ctx)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if result.Reason != ExitMerged {
+		t.Errorf("reason = %q, want %q", result.Reason, ExitMerged)
+	}
+}
+
+func TestWatcherExitOnClose(t *testing.T) {
+	source := &mockEventSource{prState: PRClosed}
+	agent := &mockAgent{}
+
+	w := NewWatcher("owner", "repo", 1, "fleet/1", "/work", Config{
+		PollInterval: 10 * time.Millisecond,
+		Timeout:      1 * time.Hour,
+		IdleTimeout:  30 * time.Minute,
+		MaxFixRounds: 5,
+	}, source, agent)
+
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+
+	result, err := w.Run(ctx)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if result.Reason != ExitClosed {
+		t.Errorf("reason = %q, want %q", result.Reason, ExitClosed)
+	}
+}
+
+func TestWatcherExitOnTimeout(t *testing.T) {
+	source := &mockEventSource{prState: PROpen}
+	agent := &mockAgent{}
+
+	w := NewWatcher("owner", "repo", 1, "fleet/1", "/work", Config{
+		PollInterval: 10 * time.Millisecond,
+		Timeout:      50 * time.Millisecond,
+		IdleTimeout:  1 * time.Hour,
+		MaxFixRounds: 5,
+	}, source, agent)
+
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+
+	result, err := w.Run(ctx)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if result.Reason != ExitTimeout {
+		t.Errorf("reason = %q, want %q", result.Reason, ExitTimeout)
+	}
+}
+
+func TestWatcherExitOnIdle(t *testing.T) {
+	source := &mockEventSource{prState: PROpen}
+	agent := &mockAgent{}
+
+	w := NewWatcher("owner", "repo", 1, "fleet/1", "/work", Config{
+		PollInterval: 10 * time.Millisecond,
+		Timeout:      1 * time.Hour,
+		IdleTimeout:  50 * time.Millisecond,
+		MaxFixRounds: 5,
+	}, source, agent)
+	// Set LastEventAt to the past so idle timeout fires immediately
+	w.LastEventAt = time.Now().Add(-1 * time.Hour)
+
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+
+	result, err := w.Run(ctx)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if result.Reason != ExitIdle {
+		t.Errorf("reason = %q, want %q", result.Reason, ExitIdle)
+	}
+}
+
+func TestWatcherExitOnContextCancel(t *testing.T) {
+	source := &mockEventSource{prState: PROpen}
+	agent := &mockAgent{}
+
+	w := NewWatcher("owner", "repo", 1, "fleet/1", "/work", Config{
+		PollInterval: 10 * time.Millisecond,
+		Timeout:      1 * time.Hour,
+		IdleTimeout:  1 * time.Hour,
+		MaxFixRounds: 5,
+	}, source, agent)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel() // immediately cancel
+
+	_, err := w.Run(ctx)
+	if err == nil {
+		t.Error("expected error from cancelled context")
+	}
+}
+
+func TestWatcherProcessesNewComments(t *testing.T) {
+	source := &mockEventSource{
+		prState: PROpen,
+		comments: []Event{
+			{ID: "comment-1", Type: EventPRComment, Body: "Please fix the typo", Author: "reviewer"},
+		},
+	}
+	agent := &mockAgent{}
+
+	w := NewWatcher("owner", "repo", 1, "fleet/1", "/work", Config{
+		PollInterval: 10 * time.Millisecond,
+		Timeout:      200 * time.Millisecond,
+		IdleTimeout:  1 * time.Hour,
+		MaxFixRounds: 5,
+	}, source, agent)
+
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+
+	_, _ = w.Run(ctx)
+
+	if !w.IsProcessed("comment-1") {
+		t.Error("comment-1 should be marked as processed")
+	}
+}
+
+func TestWatcherSkipsProcessedEvents(t *testing.T) {
+	source := &mockEventSource{
+		prState: PROpen,
+		comments: []Event{
+			{ID: "comment-1", Type: EventPRComment, Body: "Already seen"},
+		},
+	}
+	agent := &mockAgent{}
+
+	w := NewWatcher("owner", "repo", 1, "fleet/1", "/work", Config{
+		PollInterval: 10 * time.Millisecond,
+		Timeout:      200 * time.Millisecond,
+		IdleTimeout:  1 * time.Hour,
+		MaxFixRounds: 5,
+	}, source, agent)
+	w.MarkProcessed("comment-1")
+
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+
+	_, _ = w.Run(ctx)
+
+	// Agent Fix should not be called for already-processed events
+	if len(agent.fixCalls) > 0 {
+		t.Errorf("agent.Fix should not be called for processed events, got %d calls", len(agent.fixCalls))
+	}
+}
+
+func TestWatcherMaxFixRoundsExit(t *testing.T) {
+	callCount := 0
+	source := &dynamicMockEventSource{
+		prStateFn: func() PRState { return PROpen },
+		reviewsFn: func() []Event {
+			callCount++
+			return []Event{
+				{ID: fmt.Sprintf("review-%d", callCount), Type: EventReviewComment, Body: "Fix this"},
+			}
+		},
+	}
+	agent := &mockAgent{
+		decideFn: func(_ Event) (*Decision, error) {
+			return &Decision{Action: ActionFix, Message: "fixing"}, nil
+		},
+	}
+
+	w := NewWatcher("owner", "repo", 1, "fleet/1", "/work", Config{
+		PollInterval: 10 * time.Millisecond,
+		Timeout:      10 * time.Second,
+		IdleTimeout:  10 * time.Second,
+		MaxFixRounds: 3,
+	}, source, agent)
+
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+
+	result, err := w.Run(ctx)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if result.Reason != ExitMaxFixes {
+		t.Errorf("reason = %q, want %q", result.Reason, ExitMaxFixes)
+	}
+	if w.FixCount > 3 {
+		t.Errorf("fix count = %d, should not exceed max_fix_rounds (3)", w.FixCount)
+	}
+}
+
+func TestWatcherUpdatesLastEventTime(t *testing.T) {
+	before := time.Now()
+
+	source := &mockEventSource{
+		prState: PROpen,
+		comments: []Event{
+			{ID: "comment-1", Type: EventPRComment, Body: "New comment", CreatedAt: time.Now()},
+		},
+	}
+	agent := &mockAgent{}
+
+	w := NewWatcher("owner", "repo", 1, "fleet/1", "/work", Config{
+		PollInterval: 10 * time.Millisecond,
+		Timeout:      200 * time.Millisecond,
+		IdleTimeout:  1 * time.Hour,
+		MaxFixRounds: 5,
+	}, source, agent)
+	// Set LastEventAt to a known past time
+	w.LastEventAt = before.Add(-1 * time.Hour)
+
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+
+	_, _ = w.Run(ctx)
+
+	// LastEventAt should have been updated when the comment was processed
+	if w.LastEventAt.Before(before) {
+		t.Error("LastEventAt should have been updated when processing new events")
+	}
+}
+
+// ---------------------------------------------------------------------------
+// ExitReason constants
+// ---------------------------------------------------------------------------
+
+func TestExitReasonConstants(t *testing.T) {
+	tests := []struct {
+		reason ExitReason
+		str    string
+	}{
+		{ExitMerged, "merged"},
+		{ExitClosed, "closed"},
+		{ExitTimeout, "timeout"},
+		{ExitIdle, "idle"},
+		{ExitMaxFixes, "max_fixes"},
+	}
+	for _, tt := range tests {
+		if string(tt.reason) != tt.str {
+			t.Errorf("ExitReason = %q, want %q", tt.reason, tt.str)
+		}
+	}
+}


### PR DESCRIPTION
Tests for #1 by Star Fleet Test Agent.

## Test Coverage (+2405 lines)
- config_test.go: watch/ci config parsing, defaults, backward compat
- state_watch_test.go: new phases, event tracking, state persistence
- events_test.go: PR event polling, comment/review/check parsing
- handler_test.go: decision making (fix vs reply vs ignore)
- watch_test.go: watch loop lifecycle, timeout, exit conditions