### PR TITLE
feat(webhook): add automatic Issue Linter on opened/edited events

### DIFF
--- a/internal/cli/serve.go
+++ b/internal/cli/serve.go
@@ -291,42 +291,44 @@ type issueLintRunner struct {
 	cache *repocache.Cache
 }
 
-func (r *issueLintRunner) LintIssue(owner, repo string, issueNumber int) error {
+func (r *issueLintRunner) LintIssue(owner, repo string, issueNumber int) (time.Duration, error) {
 	ctx := context.Background()
 
 	repoRoot, err := r.cache.Ensure(ctx, owner, repo)
 	if err != nil {
-		return fmt.Errorf("ensuring repo clone: %w", err)
+		return 0, fmt.Errorf("ensuring repo clone: %w", err)
 	}
 
 	cfg, err := config.Load(repoRoot)
 	if err != nil {
-		return fmt.Errorf("loading config: %w", err)
+		return 0, fmt.Errorf("loading config: %w", err)
 	}
 
 	if !cfg.IssueLint.Enabled {
 		log.Printf("serve: issue lint disabled for %s/%s, skipping", owner, repo)
-		return nil
+		return 0, nil
 	}
+
+	dedupWindow := cfg.IssueLint.DedupWindow.Duration
 
 	adapter := &lintGHAdapter{}
 	linter := &issuelint.Linter{GH: adapter}
 
 	result, err := linter.Lint(ctx, owner, repo, issueNumber, &cfg.IssueLint)
 	if err != nil {
-		return fmt.Errorf("linting issue: %w", err)
+		return 0, fmt.Errorf("linting issue: %w", err)
 	}
 
 	if !result.Pass && result.Comment != "" {
 		if err := gh.PostComment(ctx, owner, repo, issueNumber, result.Comment); err != nil {
-			return fmt.Errorf("posting lint comment: %w", err)
+			return dedupWindow, fmt.Errorf("posting lint comment: %w", err)
 		}
 		log.Printf("serve: posted lint feedback on %s/%s#%d", owner, repo, issueNumber)
 	} else {
 		log.Printf("serve: issue %s/%s#%d passed lint check", owner, repo, issueNumber)
 	}
 
-	return nil
+	return dedupWindow, nil
 }
 
 // lintGHAdapter adapts the gh package functions to the issuelint.GHClient interface.

--- a/internal/cli/serve.go
+++ b/internal/cli/serve.go
@@ -17,6 +17,7 @@ import (
 	"github.com/nullne/star-fleet/internal/config"
 	"github.com/nullne/star-fleet/internal/gh"
 	"github.com/nullne/star-fleet/internal/ghapp"
+	"github.com/nullne/star-fleet/internal/issuelint"
 	"github.com/nullne/star-fleet/internal/orchestrator"
 	"github.com/nullne/star-fleet/internal/repocache"
 	"github.com/nullne/star-fleet/internal/tester"
@@ -123,6 +124,11 @@ func runServe(cmd *cobra.Command, args []string) error {
 	}
 
 	handler := webhook.NewHandler(serveLabel, serveBotUser, runner)
+
+	// Wire up the issue linter
+	linterRunner := &issueLintRunner{cache: cache}
+	handler.SetLinter(linterRunner)
+
 	srv := webhook.NewServer(servePort, cfg.secret, handler)
 
 	ctx, stop := signal.NotifyContext(cmd.Context(), syscall.SIGINT, syscall.SIGTERM)
@@ -278,4 +284,66 @@ func (a *checkRunAdapter) UpdateCheckRun(ctx context.Context, owner, repo string
 		}
 	}
 	return a.client.UpdateCheckRun(ctx, owner, repo, checkRunID, status, conclusion, ghOutput)
+}
+
+// issueLintRunner implements webhook.IssueLinter.
+type issueLintRunner struct {
+	cache *repocache.Cache
+}
+
+func (r *issueLintRunner) LintIssue(owner, repo string, issueNumber int) error {
+	ctx := context.Background()
+
+	repoRoot, err := r.cache.Ensure(ctx, owner, repo)
+	if err != nil {
+		return fmt.Errorf("ensuring repo clone: %w", err)
+	}
+
+	cfg, err := config.Load(repoRoot)
+	if err != nil {
+		return fmt.Errorf("loading config: %w", err)
+	}
+
+	if !cfg.IssueLint.Enabled {
+		log.Printf("serve: issue lint disabled for %s/%s, skipping", owner, repo)
+		return nil
+	}
+
+	adapter := &lintGHAdapter{}
+	linter := &issuelint.Linter{GH: adapter}
+
+	result, err := linter.Lint(ctx, owner, repo, issueNumber, &cfg.IssueLint)
+	if err != nil {
+		return fmt.Errorf("linting issue: %w", err)
+	}
+
+	if !result.Pass && result.Comment != "" {
+		if err := gh.PostComment(ctx, owner, repo, issueNumber, result.Comment); err != nil {
+			return fmt.Errorf("posting lint comment: %w", err)
+		}
+		log.Printf("serve: posted lint feedback on %s/%s#%d", owner, repo, issueNumber)
+	} else {
+		log.Printf("serve: issue %s/%s#%d passed lint check", owner, repo, issueNumber)
+	}
+
+	return nil
+}
+
+// lintGHAdapter adapts the gh package functions to the issuelint.GHClient interface.
+type lintGHAdapter struct{}
+
+func (a *lintGHAdapter) FetchIssue(ctx context.Context, owner, repo string, number int) (string, string, error) {
+	issue, err := gh.FetchIssue(ctx, owner, repo, number)
+	if err != nil {
+		return "", "", err
+	}
+	return issue.Title, issue.Body, nil
+}
+
+func (a *lintGHAdapter) FetchFileContent(ctx context.Context, owner, repo, path string) (string, error) {
+	return gh.FetchFileContent(ctx, owner, repo, path)
+}
+
+func (a *lintGHAdapter) PostComment(ctx context.Context, owner, repo string, number int, body string) error {
+	return gh.PostComment(ctx, owner, repo, number, body)
 }

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -12,12 +12,13 @@ import (
 )
 
 type Config struct {
-	Agent    AgentConfig    `toml:"agent"`
-	Review   ReviewConfig   `toml:"review"`
-	Watch    WatchConfig    `toml:"watch"`
-	CI       CIConfig       `toml:"ci"`
-	Test     TestConfig     `toml:"test"`
-	Telegram TelegramConfig `toml:"telegram"`
+	Agent     AgentConfig     `toml:"agent"`
+	Review    ReviewConfig    `toml:"review"`
+	Watch     WatchConfig     `toml:"watch"`
+	CI        CIConfig        `toml:"ci"`
+	Test      TestConfig      `toml:"test"`
+	Telegram  TelegramConfig  `toml:"telegram"`
+	IssueLint IssueLintConfig `toml:"issue_lint"`
 }
 
 type AgentConfig struct {
@@ -58,6 +59,13 @@ type ReviewConfig struct {
 type TelegramConfig struct {
 	BotToken string `toml:"bot_token"`
 	ChatID   string `toml:"chat_id"`
+}
+
+type IssueLintConfig struct {
+	Enabled       bool   `toml:"enabled"`
+	GuidelineFile string `toml:"guideline_file"`
+	APIKey        string `toml:"api_key"`
+	Model         string `toml:"model"`
 }
 
 // Duration wraps time.Duration to support TOML string parsing (e.g. "30s", "2h").
@@ -129,6 +137,10 @@ func Load(repoRoot string) (*Config, error) {
 		cfg.Review.AppKeyFile = v
 	}
 
+	if v := os.Getenv("FLEET_ISSUE_LINT_API_KEY"); v != "" {
+		cfg.IssueLint.APIKey = v
+	}
+
 	switch cfg.Agent.Backend {
 	case "claude-code", "cursor", "mock":
 	default:
@@ -145,6 +157,13 @@ func Load(repoRoot string) (*Config, error) {
 
 	if cfg.Review.MaxRounds < 1 {
 		cfg.Review.MaxRounds = 3
+	}
+
+	if cfg.IssueLint.Model == "" {
+		cfg.IssueLint.Model = "claude-sonnet-4-20250514"
+	}
+	if cfg.IssueLint.GuidelineFile == "" {
+		cfg.IssueLint.GuidelineFile = "docs/ISSUE-SPEC.md"
 	}
 
 	return &cfg, nil

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -62,10 +62,12 @@ type TelegramConfig struct {
 }
 
 type IssueLintConfig struct {
-	Enabled       bool   `toml:"enabled"`
-	GuidelineFile string `toml:"guideline_file"`
-	APIKey        string `toml:"api_key"`
-	Model         string `toml:"model"`
+	Enabled       bool     `toml:"enabled"`
+	GuidelineFile string   `toml:"guideline_file"`
+	APIKey        string   `toml:"api_key"`
+	Model         string   `toml:"model"`
+	Timeout       Duration `toml:"timeout"`
+	DedupWindow   Duration `toml:"dedup_window"`
 }
 
 // Duration wraps time.Duration to support TOML string parsing (e.g. "30s", "2h").
@@ -164,6 +166,15 @@ func Load(repoRoot string) (*Config, error) {
 	}
 	if cfg.IssueLint.GuidelineFile == "" {
 		cfg.IssueLint.GuidelineFile = "docs/ISSUE-SPEC.md"
+	}
+	if cfg.IssueLint.Enabled && cfg.IssueLint.APIKey == "" {
+		return nil, fmt.Errorf("issue_lint.enabled is true but no API key configured: set api_key in [issue_lint] or FLEET_ISSUE_LINT_API_KEY env var")
+	}
+	if cfg.IssueLint.Timeout.Duration == 0 {
+		cfg.IssueLint.Timeout = Duration{30 * time.Second}
+	}
+	if cfg.IssueLint.DedupWindow.Duration == 0 {
+		cfg.IssueLint.DedupWindow = Duration{5 * time.Minute}
 	}
 
 	return &cfg, nil

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -570,6 +570,126 @@ backend = "gpt-4"
 	}
 }
 
+func TestIssueLintDefaults(t *testing.T) {
+	dir := t.TempDir()
+	cfg, err := Load(dir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if cfg.IssueLint.Enabled {
+		t.Error("issue_lint.enabled should default to false")
+	}
+	if cfg.IssueLint.GuidelineFile != "docs/ISSUE-SPEC.md" {
+		t.Errorf("issue_lint.guideline_file = %q, want default", cfg.IssueLint.GuidelineFile)
+	}
+	if cfg.IssueLint.Model != "claude-sonnet-4-20250514" {
+		t.Errorf("issue_lint.model = %q, want default", cfg.IssueLint.Model)
+	}
+	if cfg.IssueLint.Timeout.Duration != 30*time.Second {
+		t.Errorf("issue_lint.timeout = %v, want 30s", cfg.IssueLint.Timeout.Duration)
+	}
+	if cfg.IssueLint.DedupWindow.Duration != 5*time.Minute {
+		t.Errorf("issue_lint.dedup_window = %v, want 5m", cfg.IssueLint.DedupWindow.Duration)
+	}
+}
+
+func TestIssueLintEnabledWithoutKey(t *testing.T) {
+	dir := t.TempDir()
+	cfgDir := filepath.Join(dir, ".fleet")
+	if err := os.MkdirAll(cfgDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+
+	data := `[agent]
+backend = "claude-code"
+
+[issue_lint]
+enabled = true
+`
+	if err := os.WriteFile(filepath.Join(cfgDir, "config.toml"), []byte(data), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	_, err := Load(dir)
+	if err == nil {
+		t.Fatal("expected error when issue_lint enabled without API key")
+	}
+	if !strings.Contains(err.Error(), "issue_lint") {
+		t.Errorf("error = %v, want to mention issue_lint", err)
+	}
+}
+
+func TestIssueLintEnabledWithKey(t *testing.T) {
+	dir := t.TempDir()
+	cfgDir := filepath.Join(dir, ".fleet")
+	if err := os.MkdirAll(cfgDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+
+	data := `[agent]
+backend = "claude-code"
+
+[issue_lint]
+enabled = true
+api_key = "sk-test-key"
+guideline_file = "AGENTS.md"
+timeout = "60s"
+dedup_window = "10m"
+`
+	if err := os.WriteFile(filepath.Join(cfgDir, "config.toml"), []byte(data), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	cfg, err := Load(dir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !cfg.IssueLint.Enabled {
+		t.Error("issue_lint.enabled should be true")
+	}
+	if cfg.IssueLint.APIKey != "sk-test-key" {
+		t.Errorf("issue_lint.api_key = %q", cfg.IssueLint.APIKey)
+	}
+	if cfg.IssueLint.GuidelineFile != "AGENTS.md" {
+		t.Errorf("issue_lint.guideline_file = %q", cfg.IssueLint.GuidelineFile)
+	}
+	if cfg.IssueLint.Timeout.Duration != 60*time.Second {
+		t.Errorf("issue_lint.timeout = %v, want 60s", cfg.IssueLint.Timeout.Duration)
+	}
+	if cfg.IssueLint.DedupWindow.Duration != 10*time.Minute {
+		t.Errorf("issue_lint.dedup_window = %v, want 10m", cfg.IssueLint.DedupWindow.Duration)
+	}
+}
+
+func TestIssueLintEnvVarOverride(t *testing.T) {
+	dir := t.TempDir()
+	cfgDir := filepath.Join(dir, ".fleet")
+	if err := os.MkdirAll(cfgDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+
+	data := `[agent]
+backend = "claude-code"
+
+[issue_lint]
+enabled = true
+api_key = "file-key"
+`
+	if err := os.WriteFile(filepath.Join(cfgDir, "config.toml"), []byte(data), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	t.Setenv("FLEET_ISSUE_LINT_API_KEY", "env-key")
+
+	cfg, err := Load(dir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if cfg.IssueLint.APIKey != "env-key" {
+		t.Errorf("issue_lint.api_key = %q, want env override %q", cfg.IssueLint.APIKey, "env-key")
+	}
+}
+
 func TestLoadFullConfig(t *testing.T) {
 	dir := t.TempDir()
 	cfgDir := filepath.Join(dir, ".fleet")

--- a/internal/gh/gh.go
+++ b/internal/gh/gh.go
@@ -3,6 +3,7 @@ package gh
 import (
 	"bytes"
 	"context"
+	"encoding/base64"
 	"encoding/json"
 	"fmt"
 	"os/exec"
@@ -11,6 +12,8 @@ import (
 
 	"github.com/nullne/star-fleet/internal/retry"
 )
+
+var base64StdDecode = base64.StdEncoding.DecodeString
 
 type Issue struct {
 	Number int    `json:"number"`
@@ -278,6 +281,36 @@ func SubmitReview(ctx context.Context, owner, repo string, prNumber int, event, 
 // a request-changes review because the reviewer is the PR author.
 func isOwnPRError(err error) bool {
 	return err != nil && strings.Contains(strings.ToLower(err.Error()), "can not request changes on your own pull request")
+}
+
+// FetchFileContent reads a file from a repository using the GitHub API.
+func FetchFileContent(ctx context.Context, owner, repo, path string) (string, error) {
+	nwo := owner + "/" + repo
+	out, err := runFn(ctx, "", "api",
+		fmt.Sprintf("repos/%s/contents/%s", nwo, path),
+		"--jq", ".content")
+	if err != nil {
+		return "", fmt.Errorf("fetching file %s: %w", path, err)
+	}
+	// GitHub returns base64-encoded content; gh --jq decodes the JSON
+	// but the content field itself is base64. Decode it.
+	content := strings.TrimSpace(out)
+	decoded, err := base64Decode(content)
+	if err != nil {
+		// If base64 decode fails, return raw (might already be decoded)
+		return content, nil
+	}
+	return decoded, nil
+}
+
+func base64Decode(s string) (string, error) {
+	// GitHub returns base64 with newlines
+	s = strings.ReplaceAll(s, "\n", "")
+	b, err := base64StdDecode(s)
+	if err != nil {
+		return "", err
+	}
+	return string(b), nil
 }
 
 func DefaultBranch(ctx context.Context, owner, repo string) (string, error) {

--- a/internal/issuelint/issuelint.go
+++ b/internal/issuelint/issuelint.go
@@ -8,6 +8,7 @@ import (
 	"io"
 	"net/http"
 	"strings"
+	"time"
 
 	"github.com/nullne/star-fleet/internal/config"
 )
@@ -46,7 +47,15 @@ func (l *Linter) Lint(ctx context.Context, owner, repo string, issueNumber int, 
 
 	prompt := buildPrompt(guideline, issueTitle, issueBody)
 
-	response, err := l.callLLM(ctx, cfg.APIKey, cfg.Model, prompt)
+	// Apply timeout to the LLM call
+	timeout := cfg.Timeout.Duration
+	if timeout == 0 {
+		timeout = 30 * time.Second
+	}
+	llmCtx, cancel := context.WithTimeout(ctx, timeout)
+	defer cancel()
+
+	response, err := l.callLLM(llmCtx, cfg.APIKey, cfg.Model, prompt)
 	if err != nil {
 		return nil, fmt.Errorf("calling LLM: %w", err)
 	}

--- a/internal/issuelint/issuelint.go
+++ b/internal/issuelint/issuelint.go
@@ -1,0 +1,208 @@
+package issuelint
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"strings"
+
+	"github.com/nullne/star-fleet/internal/config"
+)
+
+// GHClient abstracts GitHub operations needed by the linter.
+type GHClient interface {
+	FetchFileContent(ctx context.Context, owner, repo, path string) (string, error)
+	PostComment(ctx context.Context, owner, repo string, number int, body string) error
+	FetchIssue(ctx context.Context, owner, repo string, number int) (string, string, error)
+}
+
+// Linter evaluates issues against project-specific guidelines using an LLM.
+type Linter struct {
+	GH         GHClient
+	HTTPClient *http.Client
+}
+
+// LintResult holds the outcome of an issue review.
+type LintResult struct {
+	Pass    bool   // true if the issue meets the guidelines
+	Comment string // feedback to post (empty if pass and silent)
+}
+
+// Lint evaluates the given issue against the project's guideline file.
+func (l *Linter) Lint(ctx context.Context, owner, repo string, issueNumber int, cfg *config.IssueLintConfig) (*LintResult, error) {
+	issueTitle, issueBody, err := l.GH.FetchIssue(ctx, owner, repo, issueNumber)
+	if err != nil {
+		return nil, fmt.Errorf("fetching issue #%d: %w", issueNumber, err)
+	}
+
+	guideline, err := l.GH.FetchFileContent(ctx, owner, repo, cfg.GuidelineFile)
+	if err != nil {
+		// If guideline file doesn't exist, use a sensible default
+		guideline = defaultGuideline
+	}
+
+	prompt := buildPrompt(guideline, issueTitle, issueBody)
+
+	response, err := l.callLLM(ctx, cfg.APIKey, cfg.Model, prompt)
+	if err != nil {
+		return nil, fmt.Errorf("calling LLM: %w", err)
+	}
+
+	return parseResponse(response), nil
+}
+
+const defaultGuideline = `## Issue Guidelines
+
+A well-written issue should contain:
+
+1. **What** — A clear description of what needs to be done or what the problem is.
+2. **Why** — The motivation or context behind the change.
+3. **Acceptance Criteria** — A checklist of conditions that must be met for the issue to be considered complete.
+
+A good issue should NOT:
+- Dictate specific implementation details (the "How") unless there are hard constraints.
+- Be vague or ambiguous about what success looks like.
+- Lack testable acceptance criteria.
+`
+
+func buildPrompt(guideline, title, body string) string {
+	return fmt.Sprintf(`You are an issue quality reviewer for a software project. Your job is to evaluate whether a GitHub issue meets the project's guidelines.
+
+## Project Guidelines
+
+%s
+
+## Issue to Review
+
+**Title:** %s
+
+**Body:**
+%s
+
+## Instructions
+
+Evaluate the issue against the guidelines above. Respond in the following JSON format:
+
+{"pass": true}
+
+or
+
+{"pass": false, "issues": ["issue 1 description", "issue 2 description"]}
+
+Only output the JSON, nothing else. Be strict but fair — minor style issues are acceptable, but missing sections or vague requirements are not.`, guideline, title, body)
+}
+
+// anthropic API types
+type anthropicRequest struct {
+	Model     string             `json:"model"`
+	MaxTokens int                `json:"max_tokens"`
+	Messages  []anthropicMessage `json:"messages"`
+}
+
+type anthropicMessage struct {
+	Role    string `json:"role"`
+	Content string `json:"content"`
+}
+
+type anthropicResponse struct {
+	Content []struct {
+		Text string `json:"text"`
+	} `json:"content"`
+	Error *struct {
+		Message string `json:"message"`
+	} `json:"error"`
+}
+
+type llmOutput struct {
+	Pass   bool     `json:"pass"`
+	Issues []string `json:"issues"`
+}
+
+func (l *Linter) callLLM(ctx context.Context, apiKey, model, prompt string) (string, error) {
+	reqBody := anthropicRequest{
+		Model:     model,
+		MaxTokens: 1024,
+		Messages: []anthropicMessage{
+			{Role: "user", Content: prompt},
+		},
+	}
+
+	jsonBody, err := json.Marshal(reqBody)
+	if err != nil {
+		return "", fmt.Errorf("marshaling request: %w", err)
+	}
+
+	req, err := http.NewRequestWithContext(ctx, "POST", "https://api.anthropic.com/v1/messages", bytes.NewReader(jsonBody))
+	if err != nil {
+		return "", fmt.Errorf("creating request: %w", err)
+	}
+
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("x-api-key", apiKey)
+	req.Header.Set("anthropic-version", "2023-06-01")
+
+	client := l.HTTPClient
+	if client == nil {
+		client = http.DefaultClient
+	}
+
+	resp, err := client.Do(req)
+	if err != nil {
+		return "", fmt.Errorf("sending request: %w", err)
+	}
+	defer resp.Body.Close()
+
+	body, err := io.ReadAll(io.LimitReader(resp.Body, 1<<20))
+	if err != nil {
+		return "", fmt.Errorf("reading response: %w", err)
+	}
+
+	if resp.StatusCode != http.StatusOK {
+		return "", fmt.Errorf("API returned status %d: %s", resp.StatusCode, string(body))
+	}
+
+	var apiResp anthropicResponse
+	if err := json.Unmarshal(body, &apiResp); err != nil {
+		return "", fmt.Errorf("parsing response: %w", err)
+	}
+
+	if apiResp.Error != nil {
+		return "", fmt.Errorf("API error: %s", apiResp.Error.Message)
+	}
+
+	if len(apiResp.Content) == 0 {
+		return "", fmt.Errorf("empty response from API")
+	}
+
+	return apiResp.Content[0].Text, nil
+}
+
+func parseResponse(response string) *LintResult {
+	response = strings.TrimSpace(response)
+
+	var output llmOutput
+	if err := json.Unmarshal([]byte(response), &output); err != nil {
+		// If we can't parse, treat as pass to avoid blocking
+		return &LintResult{Pass: true}
+	}
+
+	if output.Pass {
+		return &LintResult{Pass: true}
+	}
+
+	var sb strings.Builder
+	sb.WriteString("## 📋 Issue Review\n\n")
+	sb.WriteString("This issue does not yet meet the project's guidelines. Please address the following:\n\n")
+	for i, issue := range output.Issues {
+		sb.WriteString(fmt.Sprintf("%d. %s\n", i+1, issue))
+	}
+	sb.WriteString("\n---\n*🤖 Automated review by Star Fleet*")
+
+	return &LintResult{
+		Pass:    false,
+		Comment: sb.String(),
+	}
+}

--- a/internal/issuelint/issuelint_test.go
+++ b/internal/issuelint/issuelint_test.go
@@ -1,0 +1,248 @@
+package issuelint
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/nullne/star-fleet/internal/config"
+)
+
+type mockGHClient struct {
+	issueTitle  string
+	issueBody   string
+	fileContent string
+	fileErr     error
+	comments    []string
+}
+
+func (m *mockGHClient) FetchIssue(ctx context.Context, owner, repo string, number int) (string, string, error) {
+	return m.issueTitle, m.issueBody, nil
+}
+
+func (m *mockGHClient) FetchFileContent(ctx context.Context, owner, repo, path string) (string, error) {
+	return m.fileContent, m.fileErr
+}
+
+func (m *mockGHClient) PostComment(ctx context.Context, owner, repo string, number int, body string) error {
+	m.comments = append(m.comments, body)
+	return nil
+}
+
+func TestParseResponse_Pass(t *testing.T) {
+	t.Parallel()
+	result := parseResponse(`{"pass": true}`)
+	if !result.Pass {
+		t.Error("expected pass=true")
+	}
+	if result.Comment != "" {
+		t.Errorf("expected empty comment, got %q", result.Comment)
+	}
+}
+
+func TestParseResponse_Fail(t *testing.T) {
+	t.Parallel()
+	result := parseResponse(`{"pass": false, "issues": ["Missing acceptance criteria", "No Why section"]}`)
+	if result.Pass {
+		t.Error("expected pass=false")
+	}
+	if result.Comment == "" {
+		t.Error("expected non-empty comment")
+	}
+	if !contains(result.Comment, "Missing acceptance criteria") {
+		t.Errorf("comment should mention first issue, got %q", result.Comment)
+	}
+	if !contains(result.Comment, "No Why section") {
+		t.Errorf("comment should mention second issue, got %q", result.Comment)
+	}
+}
+
+func TestParseResponse_InvalidJSON(t *testing.T) {
+	t.Parallel()
+	result := parseResponse("not json at all")
+	if !result.Pass {
+		t.Error("expected pass=true for unparseable response (fail-open)")
+	}
+}
+
+func TestBuildPrompt(t *testing.T) {
+	t.Parallel()
+	prompt := buildPrompt("guideline content", "My Title", "My Body")
+	if !contains(prompt, "guideline content") {
+		t.Error("prompt should contain guideline")
+	}
+	if !contains(prompt, "My Title") {
+		t.Error("prompt should contain title")
+	}
+	if !contains(prompt, "My Body") {
+		t.Error("prompt should contain body")
+	}
+}
+
+func TestLint_Pass(t *testing.T) {
+	t.Parallel()
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		resp := anthropicResponse{
+			Content: []struct {
+				Text string `json:"text"`
+			}{
+				{Text: `{"pass": true}`},
+			},
+		}
+		w.Header().Set("Content-Type", "application/json")
+		json.NewEncoder(w).Encode(resp)
+	}))
+	defer server.Close()
+
+	gh := &mockGHClient{
+		issueTitle:  "feat: add logging",
+		issueBody:   "## What\nAdd logging\n## Why\nObservability\n## Acceptance Criteria\n- [ ] Logs exist",
+		fileContent: "guideline here",
+	}
+
+	linter := &Linter{
+		GH:         gh,
+		HTTPClient: server.Client(),
+	}
+
+	// Override the API URL by using a custom transport
+	linter.HTTPClient = &http.Client{
+		Transport: &rewriteTransport{base: server.Client().Transport, url: server.URL},
+	}
+
+	cfg := &config.IssueLintConfig{
+		Enabled:       true,
+		GuidelineFile: "docs/ISSUE-SPEC.md",
+		APIKey:        "test-key",
+		Model:         "claude-sonnet-4-20250514",
+	}
+
+	result, err := linter.Lint(context.Background(), "owner", "repo", 1, cfg)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !result.Pass {
+		t.Error("expected pass")
+	}
+}
+
+func TestLint_Fail(t *testing.T) {
+	t.Parallel()
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		resp := anthropicResponse{
+			Content: []struct {
+				Text string `json:"text"`
+			}{
+				{Text: `{"pass": false, "issues": ["Missing Why section"]}`},
+			},
+		}
+		w.Header().Set("Content-Type", "application/json")
+		json.NewEncoder(w).Encode(resp)
+	}))
+	defer server.Close()
+
+	gh := &mockGHClient{
+		issueTitle:  "fix something",
+		issueBody:   "just fix it",
+		fileContent: "guideline here",
+	}
+
+	linter := &Linter{
+		GH:         gh,
+		HTTPClient: &http.Client{Transport: &rewriteTransport{base: server.Client().Transport, url: server.URL}},
+	}
+
+	cfg := &config.IssueLintConfig{
+		Enabled:       true,
+		GuidelineFile: "docs/ISSUE-SPEC.md",
+		APIKey:        "test-key",
+		Model:         "claude-sonnet-4-20250514",
+	}
+
+	result, err := linter.Lint(context.Background(), "owner", "repo", 1, cfg)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if result.Pass {
+		t.Error("expected fail")
+	}
+	if !contains(result.Comment, "Missing Why section") {
+		t.Errorf("comment should contain issue, got %q", result.Comment)
+	}
+}
+
+func TestLint_MissingGuideline_UsesDefault(t *testing.T) {
+	t.Parallel()
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		resp := anthropicResponse{
+			Content: []struct {
+				Text string `json:"text"`
+			}{
+				{Text: `{"pass": true}`},
+			},
+		}
+		w.Header().Set("Content-Type", "application/json")
+		json.NewEncoder(w).Encode(resp)
+	}))
+	defer server.Close()
+
+	gh := &mockGHClient{
+		issueTitle: "feat: something",
+		issueBody:  "body",
+		fileErr:    fmt.Errorf("not found"),
+	}
+
+	linter := &Linter{
+		GH:         gh,
+		HTTPClient: &http.Client{Transport: &rewriteTransport{base: server.Client().Transport, url: server.URL}},
+	}
+
+	cfg := &config.IssueLintConfig{
+		Enabled:       true,
+		GuidelineFile: "nonexistent.md",
+		APIKey:        "test-key",
+		Model:         "claude-sonnet-4-20250514",
+	}
+
+	result, err := linter.Lint(context.Background(), "owner", "repo", 1, cfg)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !result.Pass {
+		t.Error("expected pass")
+	}
+}
+
+// rewriteTransport redirects all requests to the test server URL.
+type rewriteTransport struct {
+	base http.RoundTripper
+	url  string
+}
+
+func (t *rewriteTransport) RoundTrip(req *http.Request) (*http.Response, error) {
+	req.URL.Scheme = "http"
+	req.URL.Host = t.url[len("http://"):]
+	if t.base != nil {
+		return t.base.RoundTrip(req)
+	}
+	return http.DefaultTransport.RoundTrip(req)
+}
+
+func contains(s, substr string) bool {
+	return len(s) >= len(substr) && searchString(s, substr)
+}
+
+func searchString(s, substr string) bool {
+	for i := 0; i <= len(s)-len(substr); i++ {
+		if s[i:i+len(substr)] == substr {
+			return true
+		}
+	}
+	return false
+}

--- a/internal/webhook/handler.go
+++ b/internal/webhook/handler.go
@@ -17,7 +17,9 @@ type Runner interface {
 
 // IssueLinter abstracts the issue linting process, allowing injection for testing.
 type IssueLinter interface {
-	LintIssue(owner, repo string, issueNumber int) error
+	// LintIssue runs the lint check. Returns the configured dedup window
+	// (zero means use handler default) and any error.
+	LintIssue(owner, repo string, issueNumber int) (dedupWindow time.Duration, err error)
 }
 
 // Handler routes GitHub webhook events to the fleet pipeline.
@@ -295,9 +297,20 @@ func (h *Handler) tryLint(owner, repo string, number int) (string, error) {
 		}()
 
 		log.Printf("handler: starting issue lint for %s#%d", key, number)
-		if err := h.linter.LintIssue(owner, repo, number); err != nil {
+		cfgWindow, err := h.linter.LintIssue(owner, repo, number)
+		if err != nil {
 			log.Printf("handler: issue lint failed for %s#%d: %v", key, number, err)
+			// Clear dedup on failure so the next event can retry
+			h.mu.Lock()
+			delete(h.lintDedup, dedupKey)
+			h.mu.Unlock()
 			return
+		}
+		// Update dedup window from per-repo config if provided
+		if cfgWindow > 0 {
+			h.mu.Lock()
+			h.dedupWindow = cfgWindow
+			h.mu.Unlock()
 		}
 		log.Printf("handler: issue lint completed for %s#%d", key, number)
 	}()

--- a/internal/webhook/handler.go
+++ b/internal/webhook/handler.go
@@ -6,6 +6,7 @@ import (
 	"log"
 	"strings"
 	"sync"
+	"time"
 )
 
 // Runner abstracts the fleet pipeline execution, allowing injection for testing.
@@ -21,15 +22,17 @@ type IssueLinter interface {
 
 // Handler routes GitHub webhook events to the fleet pipeline.
 type Handler struct {
-	label   string
-	botUser string
-	runner  Runner
-	linter  IssueLinter
+	label       string
+	botUser     string
+	runner      Runner
+	linter      IssueLinter
+	dedupWindow time.Duration // dedup window for edited events (default 5m)
 
-	mu      sync.Mutex
-	running map[string]bool // per-repo busy tracking: "owner/repo" -> true
-	testing map[string]bool // per-repo busy tracking for test runs
-	linting map[string]bool // per-repo busy tracking for issue lint
+	mu        sync.Mutex
+	running   map[string]bool      // per-repo busy tracking: "owner/repo" -> true
+	testing   map[string]bool      // per-repo busy tracking for test runs
+	linting   map[string]bool      // per-repo busy tracking for issue lint
+	lintDedup map[string]time.Time // "owner/repo#number" -> last lint time
 }
 
 // NewHandler creates an event handler.
@@ -38,18 +41,25 @@ type Handler struct {
 //   - runner: executes the fleet pipeline
 func NewHandler(label, botUser string, runner Runner) *Handler {
 	return &Handler{
-		label:   label,
-		botUser: botUser,
-		runner:  runner,
-		running: make(map[string]bool),
-		testing: make(map[string]bool),
-		linting: make(map[string]bool),
+		label:       label,
+		botUser:     botUser,
+		runner:      runner,
+		dedupWindow: 5 * time.Minute,
+		running:     make(map[string]bool),
+		testing:     make(map[string]bool),
+		linting:     make(map[string]bool),
+		lintDedup:   make(map[string]time.Time),
 	}
 }
 
 // SetLinter configures an optional issue linter for opened/edited events.
 func (h *Handler) SetLinter(linter IssueLinter) {
 	h.linter = linter
+}
+
+// SetDedupWindow configures the dedup window for issue lint events.
+func (h *Handler) SetDedupWindow(d time.Duration) {
+	h.dedupWindow = d
 }
 
 // HandleEvent parses a webhook payload and dispatches it. It returns a short
@@ -257,14 +267,21 @@ func (h *Handler) tryTest(owner, repo, headSHA string, prNumber int) (string, er
 
 func (h *Handler) tryLint(owner, repo string, number int) (string, error) {
 	key := repoKey(owner, repo)
+	dedupKey := fmt.Sprintf("%s#%d", key, number)
 
 	h.mu.Lock()
+	if last, ok := h.lintDedup[dedupKey]; ok && time.Since(last) < h.dedupWindow {
+		h.mu.Unlock()
+		log.Printf("handler: %s issue #%d linted %v ago, dedup skipping", key, number, time.Since(last).Round(time.Second))
+		return "skipped", nil
+	}
 	if h.linting[key] {
 		h.mu.Unlock()
 		log.Printf("handler: %s lint already running, rejecting issue #%d", key, number)
 		return "busy", nil
 	}
 	h.linting[key] = true
+	h.lintDedup[dedupKey] = time.Now()
 	h.mu.Unlock()
 
 	go func() {

--- a/internal/webhook/handler.go
+++ b/internal/webhook/handler.go
@@ -14,15 +14,22 @@ type Runner interface {
 	Test(owner, repo, headSHA string, prNumber int) error
 }
 
+// IssueLinter abstracts the issue linting process, allowing injection for testing.
+type IssueLinter interface {
+	LintIssue(owner, repo string, issueNumber int) error
+}
+
 // Handler routes GitHub webhook events to the fleet pipeline.
 type Handler struct {
 	label   string
 	botUser string
 	runner  Runner
+	linter  IssueLinter
 
 	mu      sync.Mutex
 	running map[string]bool // per-repo busy tracking: "owner/repo" -> true
 	testing map[string]bool // per-repo busy tracking for test runs
+	linting map[string]bool // per-repo busy tracking for issue lint
 }
 
 // NewHandler creates an event handler.
@@ -36,7 +43,13 @@ func NewHandler(label, botUser string, runner Runner) *Handler {
 		runner:  runner,
 		running: make(map[string]bool),
 		testing: make(map[string]bool),
+		linting: make(map[string]bool),
 	}
+}
+
+// SetLinter configures an optional issue linter for opened/edited events.
+func (h *Handler) SetLinter(linter IssueLinter) {
+	h.linter = linter
 }
 
 // HandleEvent parses a webhook payload and dispatches it. It returns a short
@@ -121,23 +134,39 @@ func (h *Handler) handleIssues(payload []byte) (string, error) {
 		return "", fmt.Errorf("parsing issues payload: %w", err)
 	}
 
-	if p.Action != "labeled" {
-		log.Printf("handler: issues event action=%q, ignoring (want labeled)", p.Action)
+	switch p.Action {
+	case "labeled":
+		if !strings.EqualFold(p.Label.Name, h.label) {
+			log.Printf("handler: label %q does not match %q, skipping", p.Label.Name, h.label)
+			return "skipped", nil
+		}
+
+		if h.isBot(p.Sender) {
+			log.Printf("handler: ignoring event from bot user %q", p.Sender.Login)
+			return "skipped", nil
+		}
+
+		log.Printf("handler: issue #%d labeled with %q — triggering run", p.Issue.Number, h.label)
+		return h.tryRun(p.Repo.Owner.Login, p.Repo.Name, p.Issue.Number)
+
+	case "opened", "edited":
+		if h.isBot(p.Sender) {
+			log.Printf("handler: ignoring %s event from bot user %q", p.Action, p.Sender.Login)
+			return "skipped", nil
+		}
+
+		if h.linter == nil {
+			log.Printf("handler: issues event action=%q, no linter configured, ignoring", p.Action)
+			return "ignored", nil
+		}
+
+		log.Printf("handler: issue #%d %s — triggering lint", p.Issue.Number, p.Action)
+		return h.tryLint(p.Repo.Owner.Login, p.Repo.Name, p.Issue.Number)
+
+	default:
+		log.Printf("handler: issues event action=%q, ignoring", p.Action)
 		return "ignored", nil
 	}
-
-	if !strings.EqualFold(p.Label.Name, h.label) {
-		log.Printf("handler: label %q does not match %q, skipping", p.Label.Name, h.label)
-		return "skipped", nil
-	}
-
-	if h.isBot(p.Sender) {
-		log.Printf("handler: ignoring event from bot user %q", p.Sender.Login)
-		return "skipped", nil
-	}
-
-	log.Printf("handler: issue #%d labeled with %q — triggering run", p.Issue.Number, h.label)
-	return h.tryRun(p.Repo.Owner.Login, p.Repo.Name, p.Issue.Number)
 }
 
 func (h *Handler) handleIssueComment(payload []byte) (string, error) {
@@ -221,6 +250,39 @@ func (h *Handler) tryTest(owner, repo, headSHA string, prNumber int) (string, er
 			return
 		}
 		log.Printf("handler: fleet test completed for %s#%d", key, prNumber)
+	}()
+
+	return "triggered", nil
+}
+
+func (h *Handler) tryLint(owner, repo string, number int) (string, error) {
+	key := repoKey(owner, repo)
+
+	h.mu.Lock()
+	if h.linting[key] {
+		h.mu.Unlock()
+		log.Printf("handler: %s lint already running, rejecting issue #%d", key, number)
+		return "busy", nil
+	}
+	h.linting[key] = true
+	h.mu.Unlock()
+
+	go func() {
+		defer func() {
+			if r := recover(); r != nil {
+				log.Printf("handler: panic in issue lint for %s#%d: %v", key, number, r)
+			}
+			h.mu.Lock()
+			delete(h.linting, key)
+			h.mu.Unlock()
+		}()
+
+		log.Printf("handler: starting issue lint for %s#%d", key, number)
+		if err := h.linter.LintIssue(owner, repo, number); err != nil {
+			log.Printf("handler: issue lint failed for %s#%d: %v", key, number, err)
+			return
+		}
+		log.Printf("handler: issue lint completed for %s#%d", key, number)
 	}()
 
 	return "triggered", nil

--- a/internal/webhook/handler.go
+++ b/internal/webhook/handler.go
@@ -28,13 +28,14 @@ type Handler struct {
 	botUser     string
 	runner      Runner
 	linter      IssueLinter
-	dedupWindow time.Duration // dedup window for edited events (default 5m)
+	dedupWindow time.Duration // default dedup window for edited events (5m)
 
-	mu        sync.Mutex
-	running   map[string]bool      // per-repo busy tracking: "owner/repo" -> true
-	testing   map[string]bool      // per-repo busy tracking for test runs
-	linting   map[string]bool      // per-repo busy tracking for issue lint
-	lintDedup map[string]time.Time // "owner/repo#number" -> last lint time
+	mu              sync.Mutex
+	running         map[string]bool          // per-repo busy tracking: "owner/repo" -> true
+	testing         map[string]bool          // per-repo busy tracking for test runs
+	linting         map[string]bool          // per-repo busy tracking for issue lint
+	lintDedup       map[string]time.Time     // "owner/repo#number" -> last lint time
+	repoDedupWindow map[string]time.Duration // "owner/repo" -> per-repo dedup window
 }
 
 // NewHandler creates an event handler.
@@ -43,14 +44,15 @@ type Handler struct {
 //   - runner: executes the fleet pipeline
 func NewHandler(label, botUser string, runner Runner) *Handler {
 	return &Handler{
-		label:       label,
-		botUser:     botUser,
-		runner:      runner,
-		dedupWindow: 5 * time.Minute,
-		running:     make(map[string]bool),
-		testing:     make(map[string]bool),
-		linting:     make(map[string]bool),
-		lintDedup:   make(map[string]time.Time),
+		label:           label,
+		botUser:         botUser,
+		runner:          runner,
+		dedupWindow:     5 * time.Minute,
+		running:         make(map[string]bool),
+		testing:         make(map[string]bool),
+		linting:         make(map[string]bool),
+		lintDedup:       make(map[string]time.Time),
+		repoDedupWindow: make(map[string]time.Duration),
 	}
 }
 
@@ -272,7 +274,11 @@ func (h *Handler) tryLint(owner, repo string, number int) (string, error) {
 	dedupKey := fmt.Sprintf("%s#%d", key, number)
 
 	h.mu.Lock()
-	if last, ok := h.lintDedup[dedupKey]; ok && time.Since(last) < h.dedupWindow {
+	window := h.dedupWindow
+	if w, ok := h.repoDedupWindow[key]; ok {
+		window = w
+	}
+	if last, ok := h.lintDedup[dedupKey]; ok && time.Since(last) < window {
 		h.mu.Unlock()
 		log.Printf("handler: %s issue #%d linted %v ago, dedup skipping", key, number, time.Since(last).Round(time.Second))
 		return "skipped", nil
@@ -306,10 +312,10 @@ func (h *Handler) tryLint(owner, repo string, number int) (string, error) {
 			h.mu.Unlock()
 			return
 		}
-		// Update dedup window from per-repo config if provided
+		// Update per-repo dedup window from config if provided
 		if cfgWindow > 0 {
 			h.mu.Lock()
-			h.dedupWindow = cfgWindow
+			h.repoDedupWindow[key] = cfgWindow
 			h.mu.Unlock()
 		}
 		log.Printf("handler: issue lint completed for %s#%d", key, number)

--- a/internal/webhook/handler_test.go
+++ b/internal/webhook/handler_test.go
@@ -349,6 +349,47 @@ func TestHandleIssues_OpenedBotSkipped(t *testing.T) {
 	}
 }
 
+func TestTryLint_DedupSkipsRecentLint(t *testing.T) {
+	t.Parallel()
+
+	runner := newStubRunner()
+	linter := newStubLinter()
+	h := NewHandler("fleet", "", runner)
+	h.SetLinter(linter)
+	h.SetDedupWindow(1 * time.Hour) // long window so second event is always deduped
+
+	p := issuesPayload{
+		Action: "opened",
+		Issue:  payloadIssue{Number: 42, Title: "test"},
+		Sender: payloadUser{Login: "alice", Type: "User"},
+		Repo:   payloadRepo{Name: "r"},
+	}
+	p.Repo.Owner.Login = "o"
+	body, _ := json.Marshal(p)
+
+	// First event: should trigger
+	status1, err := h.HandleEvent("issues", body)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if status1 != "triggered" {
+		t.Errorf("first status = %q, want %q", status1, "triggered")
+	}
+
+	linter.waitDone(t)
+
+	// Second event for same issue: should be deduped
+	p.Action = "edited"
+	body2, _ := json.Marshal(p)
+	status2, err := h.HandleEvent("issues", body2)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if status2 != "skipped" {
+		t.Errorf("second status = %q, want %q (should be deduped)", status2, "skipped")
+	}
+}
+
 func TestTryLint_RejectWhenBusy(t *testing.T) {
 	t.Parallel()
 

--- a/internal/webhook/handler_test.go
+++ b/internal/webhook/handler_test.go
@@ -69,6 +69,65 @@ func (r *stubRunner) Test(owner, repo, headSHA string, prNumber int) error {
 	return r.testErr
 }
 
+// --- stub linter ---
+
+type lintCall struct {
+	Owner  string
+	Repo   string
+	Number int
+}
+
+type stubLinter struct {
+	mu      sync.Mutex
+	calls   []lintCall
+	blockCh chan struct{}
+	doneCh  chan struct{}
+	err     error
+}
+
+func newStubLinter() *stubLinter {
+	return &stubLinter{
+		doneCh: make(chan struct{}, 10),
+	}
+}
+
+func newBlockingStubLinter() *stubLinter {
+	return &stubLinter{
+		blockCh: make(chan struct{}),
+		doneCh:  make(chan struct{}, 10),
+	}
+}
+
+func (l *stubLinter) LintIssue(owner, repo string, issueNumber int) error {
+	if l.blockCh != nil {
+		<-l.blockCh
+	}
+	l.mu.Lock()
+	l.calls = append(l.calls, lintCall{owner, repo, issueNumber})
+	l.mu.Unlock()
+	if l.doneCh != nil {
+		l.doneCh <- struct{}{}
+	}
+	return l.err
+}
+
+func (l *stubLinter) getCalls() []lintCall {
+	l.mu.Lock()
+	defer l.mu.Unlock()
+	out := make([]lintCall, len(l.calls))
+	copy(out, l.calls)
+	return out
+}
+
+func (l *stubLinter) waitDone(t *testing.T) {
+	t.Helper()
+	select {
+	case <-l.doneCh:
+	case <-time.After(5 * time.Second):
+		t.Fatal("timed out waiting for lint to complete")
+	}
+}
+
 func (r *stubRunner) getCalls() []runCall {
 	r.mu.Lock()
 	defer r.mu.Unlock()
@@ -160,7 +219,7 @@ func TestHandleIssues_WrongAction(t *testing.T) {
 	runner := newStubRunner()
 	h := NewHandler("fleet", "", runner)
 
-	p := issuesPayload{Action: "opened"}
+	p := issuesPayload{Action: "closed"}
 	body, _ := json.Marshal(p)
 
 	status, err := h.HandleEvent("issues", body)
@@ -170,6 +229,172 @@ func TestHandleIssues_WrongAction(t *testing.T) {
 	if status != "ignored" {
 		t.Errorf("status = %q, want %q", status, "ignored")
 	}
+}
+
+func TestHandleIssues_OpenedNoLinter(t *testing.T) {
+	t.Parallel()
+
+	runner := newStubRunner()
+	h := NewHandler("fleet", "", runner)
+
+	p := issuesPayload{
+		Action: "opened",
+		Issue:  payloadIssue{Number: 5, Title: "test"},
+		Sender: payloadUser{Login: "alice", Type: "User"},
+		Repo:   payloadRepo{Name: "r"},
+	}
+	p.Repo.Owner.Login = "o"
+	body, _ := json.Marshal(p)
+
+	status, err := h.HandleEvent("issues", body)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if status != "ignored" {
+		t.Errorf("status = %q, want %q (no linter configured)", status, "ignored")
+	}
+}
+
+func TestHandleIssues_OpenedWithLinter(t *testing.T) {
+	t.Parallel()
+
+	runner := newStubRunner()
+	linter := newStubLinter()
+	h := NewHandler("fleet", "", runner)
+	h.SetLinter(linter)
+
+	p := issuesPayload{
+		Action: "opened",
+		Issue:  payloadIssue{Number: 12, Title: "feat: new feature"},
+		Sender: payloadUser{Login: "alice", Type: "User"},
+		Repo:   payloadRepo{Name: "star-fleet"},
+	}
+	p.Repo.Owner.Login = "nullne"
+	body, _ := json.Marshal(p)
+
+	status, err := h.HandleEvent("issues", body)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if status != "triggered" {
+		t.Errorf("status = %q, want %q", status, "triggered")
+	}
+
+	linter.waitDone(t)
+	calls := linter.getCalls()
+	if len(calls) != 1 {
+		t.Fatalf("got %d lint calls, want 1", len(calls))
+	}
+	if calls[0].Owner != "nullne" || calls[0].Repo != "star-fleet" || calls[0].Number != 12 {
+		t.Errorf("call = %+v, want {nullne star-fleet 12}", calls[0])
+	}
+}
+
+func TestHandleIssues_EditedWithLinter(t *testing.T) {
+	t.Parallel()
+
+	runner := newStubRunner()
+	linter := newStubLinter()
+	h := NewHandler("fleet", "", runner)
+	h.SetLinter(linter)
+
+	p := issuesPayload{
+		Action: "edited",
+		Issue:  payloadIssue{Number: 8, Title: "fix: something"},
+		Sender: payloadUser{Login: "bob", Type: "User"},
+		Repo:   payloadRepo{Name: "repo"},
+	}
+	p.Repo.Owner.Login = "org"
+	body, _ := json.Marshal(p)
+
+	status, err := h.HandleEvent("issues", body)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if status != "triggered" {
+		t.Errorf("status = %q, want %q", status, "triggered")
+	}
+
+	linter.waitDone(t)
+	calls := linter.getCalls()
+	if len(calls) != 1 {
+		t.Fatalf("got %d lint calls, want 1", len(calls))
+	}
+	if calls[0].Number != 8 {
+		t.Errorf("number = %d, want 8", calls[0].Number)
+	}
+}
+
+func TestHandleIssues_OpenedBotSkipped(t *testing.T) {
+	t.Parallel()
+
+	runner := newStubRunner()
+	linter := newStubLinter()
+	h := NewHandler("fleet", "my-bot[bot]", runner)
+	h.SetLinter(linter)
+
+	p := issuesPayload{
+		Action: "opened",
+		Issue:  payloadIssue{Number: 3},
+		Sender: payloadUser{Login: "my-bot[bot]", Type: "Bot"},
+	}
+	body, _ := json.Marshal(p)
+
+	status, err := h.HandleEvent("issues", body)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if status != "skipped" {
+		t.Errorf("status = %q, want %q", status, "skipped")
+	}
+}
+
+func TestTryLint_RejectWhenBusy(t *testing.T) {
+	t.Parallel()
+
+	runner := newStubRunner()
+	linter := newBlockingStubLinter()
+	h := NewHandler("fleet", "", runner)
+	h.SetLinter(linter)
+
+	p1 := issuesPayload{
+		Action: "opened",
+		Issue:  payloadIssue{Number: 1},
+		Sender: payloadUser{Login: "alice", Type: "User"},
+		Repo:   payloadRepo{Name: "r"},
+	}
+	p1.Repo.Owner.Login = "o"
+	body1, _ := json.Marshal(p1)
+
+	status1, err := h.HandleEvent("issues", body1)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if status1 != "triggered" {
+		t.Errorf("first status = %q, want %q", status1, "triggered")
+	}
+
+	time.Sleep(20 * time.Millisecond)
+
+	p2 := issuesPayload{
+		Action: "opened",
+		Issue:  payloadIssue{Number: 2},
+		Sender: payloadUser{Login: "bob", Type: "User"},
+		Repo:   payloadRepo{Name: "r"},
+	}
+	p2.Repo.Owner.Login = "o"
+	body2, _ := json.Marshal(p2)
+
+	status2, err := h.HandleEvent("issues", body2)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if status2 != "busy" {
+		t.Errorf("second status = %q, want %q", status2, "busy")
+	}
+
+	close(linter.blockCh)
+	linter.waitDone(t)
 }
 
 func TestHandleIssues_BotSender(t *testing.T) {

--- a/internal/webhook/handler_test.go
+++ b/internal/webhook/handler_test.go
@@ -2,6 +2,7 @@ package webhook
 
 import (
 	"encoding/json"
+	"fmt"
 	"sync"
 	"testing"
 	"time"
@@ -98,7 +99,7 @@ func newBlockingStubLinter() *stubLinter {
 	}
 }
 
-func (l *stubLinter) LintIssue(owner, repo string, issueNumber int) error {
+func (l *stubLinter) LintIssue(owner, repo string, issueNumber int) (time.Duration, error) {
 	if l.blockCh != nil {
 		<-l.blockCh
 	}
@@ -108,7 +109,7 @@ func (l *stubLinter) LintIssue(owner, repo string, issueNumber int) error {
 	if l.doneCh != nil {
 		l.doneCh <- struct{}{}
 	}
-	return l.err
+	return 0, l.err
 }
 
 func (l *stubLinter) getCalls() []lintCall {
@@ -388,6 +389,52 @@ func TestTryLint_DedupSkipsRecentLint(t *testing.T) {
 	if status2 != "skipped" {
 		t.Errorf("second status = %q, want %q (should be deduped)", status2, "skipped")
 	}
+}
+
+func TestTryLint_DedupClearedOnFailure(t *testing.T) {
+	t.Parallel()
+
+	runner := newStubRunner()
+	linter := newStubLinter()
+	linter.err = fmt.Errorf("API error")
+	h := NewHandler("fleet", "", runner)
+	h.SetLinter(linter)
+	h.SetDedupWindow(1 * time.Hour)
+
+	p := issuesPayload{
+		Action: "opened",
+		Issue:  payloadIssue{Number: 99, Title: "test"},
+		Sender: payloadUser{Login: "alice", Type: "User"},
+		Repo:   payloadRepo{Name: "r"},
+	}
+	p.Repo.Owner.Login = "o"
+	body, _ := json.Marshal(p)
+
+	// First event: triggers but fails
+	status1, err := h.HandleEvent("issues", body)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if status1 != "triggered" {
+		t.Errorf("first status = %q, want %q", status1, "triggered")
+	}
+
+	linter.waitDone(t)
+	time.Sleep(20 * time.Millisecond) // let dedup cleanup happen
+
+	// Second event: should trigger again (dedup cleared on failure)
+	linter.err = nil
+	p.Action = "edited"
+	body2, _ := json.Marshal(p)
+	status2, err := h.HandleEvent("issues", body2)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if status2 != "triggered" {
+		t.Errorf("second status = %q, want %q (dedup should be cleared after failure)", status2, "triggered")
+	}
+
+	linter.waitDone(t)
 }
 
 func TestTryLint_RejectWhenBusy(t *testing.T) {


### PR DESCRIPTION
## Summary

Implements #68. Adds an automatic issue quality review system that evaluates GitHub issues against project-specific guidelines when they are opened or edited.

- **New `internal/issuelint/` package** — Stateless LLM-based issue reviewer using the Anthropic Messages API. Reads a project guideline file (e.g. `docs/ISSUE-SPEC.md`) from the repo and evaluates the issue body against it. Posts a structured comment if the issue fails review.
- **Webhook handler changes** — `handleIssues` now routes `opened`/`edited` actions to an `IssueLinter` interface (alongside the existing `labeled` → pipeline trigger). Includes per-repo concurrency control and bot-sender filtering.
- **Config extension** — New `[issue_lint]` section in `.fleet/config.toml` with `enabled`, `guideline_file`, `api_key`, and `model` fields. Supports `FLEET_ISSUE_LINT_API_KEY` env var override.
- **`gh.FetchFileContent`** — New function to read files from a repo via the GitHub Contents API.

## Test plan

- [x] All existing tests pass (only pre-existing `TestCursorBackendRun` failure due to missing cursor CLI)
- [x] New handler tests: opened/edited routing, no-linter fallback, bot filtering, concurrency rejection
- [x] New issuelint tests: pass/fail parsing, LLM mock integration, missing guideline fallback
- [x] Config tests for `[issue_lint]` section loading and defaults

## Configuration

```toml
[issue_lint]
enabled = true
guideline_file = "docs/ISSUE-SPEC.md"  # default
model = "claude-sonnet-4-20250514"         # default
# api_key via FLEET_ISSUE_LINT_API_KEY env var
```

Closes #68

🤖 Generated with [Claude Code](https://claude.com/claude-code)